### PR TITLE
[feat] IRSA/Workload identity support and two-phase detection

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-This is a **cloud provider authentication library** that only really works when running on actual cloud service providers (AWS, GCP, Azure). The library detects the current cloud environment and provides JWT tokens for database and API access using cloud provider identities.
+This is a **cloud provider authentication library** that only really works when running on actual cloud service providers (AWS, GCP, Azure). The library detects the current cloud environment and provides JWTs for database and API access using cloud provider identities.
 
 **Key Point:** This is not a typical library that can be fully tested locally - it requires real cloud metadata services to function properly.
 

--- a/.github/workflows/cloud_provider.yml
+++ b/.github/workflows/cloud_provider.yml
@@ -12,8 +12,8 @@ permissions:
 # Self-hosted cloud test hosts for cloud provider testing.
 # Assuming Ubuntu environment on AWS EC2, GCP Compute Engine, or Azure VM.
 #
-# Base system setup:
-# copy over the Makefile and "make dev-setup"
+# Base system setup (Ubuntu hosts expected):
+# copy over the Makefile and run: make dev-setup-ubuntu
 #
 # AWS EC2 setup:
 # sudo snap install aws-cli --classic

--- a/.github/workflows/cloud_provider.yml
+++ b/.github/workflows/cloud_provider.yml
@@ -13,7 +13,7 @@ permissions:
 # Assuming Ubuntu environment on AWS EC2, GCP Compute Engine, or Azure VM.
 #
 # Base system setup:
-# copy over the Makefile and "make install"
+# copy over the Makefile and "make dev-setup"
 #
 # AWS EC2 setup:
 # sudo snap install aws-cli --classic

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ test: test-local
 	@echo "✓ All local tests completed"
 
 test-local: test-go-local test-python-local
+	! git grep -i 'jwt[ _]token'
 	@echo "✓ All local tests passed"
 
 test-go-local:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,10 @@ UNIQUE_DIR := dev-$(shell echo $$(( ( $(shell date +%s) / 60 ) % 3 + 1 )))
 endif
 export UNIQUE_DIR
 
-.PHONY: help test test-local test-go-local test-python-local on-remote-test on-remote-test-go on-remote-test-python check-cloud-env check-host clean dev-setup dev-setup-common dev-setup-go dev-setup-python lint lint-go lint-python format format-go format-python ssh-copy-to-remote ssh-run-remote-tests ssh-download-coverage ssh-download-coverage-go ssh-download-coverage-python ssh-cleanup-remote
+.PHONY: help test test-local test-go-local test-python-local on-remote-test on-remote-test-go on-remote-test-python check-cloud-env check-host clean \
+ dev-setup-ubuntu dev-setup-macos \
+ dev-setup-ubuntu-go dev-setup-ubuntu-python dev-setup-macos-go dev-setup-macos-python \
+ dev-setup-common lint lint-go lint-python format format-go format-python ssh-copy-to-remote ssh-run-remote-tests ssh-download-coverage ssh-download-coverage-go ssh-download-coverage-python ssh-cleanup-remote
 
 # Default target
 help:
@@ -42,9 +45,12 @@ help:
 	@echo "    make ssh-cleanup-remote                 Clean up remote directory on HOST"
 	@echo ""
 	@echo "Development Setup:"
-	@echo "  make dev-setup                            Full development setup (Go + Python tooling)"
-	@echo "  make dev-setup-go                         Go development tooling (modules + linters)"
-	@echo "  make dev-setup-python                     Python development tooling (system + pip dev deps)"
+	@echo "  make dev-setup-ubuntu                     Full dev setup Ubuntu/Debian (Go + Python)"
+	@echo "  make dev-setup-ubuntu-go                  Ubuntu/Debian Go toolchain + linters"
+	@echo "  make dev-setup-ubuntu-python              Ubuntu/Debian Python tooling + deps"
+	@echo "  make dev-setup-macos                      Full dev setup macOS (Go + Python)"
+	@echo "  make dev-setup-macos-go                   macOS Go toolchain + linters"
+	@echo "  make dev-setup-macos-python               macOS Python tooling + deps"
 	@echo ""
 	@echo "Code Quality:"
 	@echo "  make lint                                 Run all linters"
@@ -119,25 +125,38 @@ on-remote-test-python: check-cloud-env
 	@echo "Environment: S2IAM_TEST_CLOUD_PROVIDER_NO_ROLE=$${S2IAM_TEST_CLOUD_PROVIDER_NO_ROLE:-<unset>}"
 	@echo "Environment: S2IAM_TEST_ASSUME_ROLE=$${S2IAM_TEST_ASSUME_ROLE:-<unset>}"
 	# Add src to PYTHONPATH so tests can import s2iam without installation
-	cd python && PYTHONPATH=src python3 -m pytest tests/ -v --tb=short
-	cd python && PYTHONPATH=src python3 -m pytest tests/ --cov=src/s2iam --cov-report=xml:coverage.xml --cov-report=html:htmlcov
+	cd python && PYTHONPATH=src python3 -m pytest tests/ -v --tb=short --cov=src/s2iam --cov-report=xml:coverage.xml --cov-report=html:htmlcov
 
-dev-setup: dev-setup-go dev-setup-python
-	@echo "✓ Full development environment ready"
+dev-setup-ubuntu: dev-setup-ubuntu-go dev-setup-ubuntu-python
+	@echo "✓ Full Ubuntu/Debian development environment ready"
+
+dev-setup-macos: dev-setup-macos-go dev-setup-macos-python
+	@echo "✓ Full macOS development environment ready"
 
 dev-setup-common:
 	sudo apt update
-	sudo snap install go --classic
+	sudo snap install go --classic || sudo apt install -y golang
 	cd go && go mod download
 
-dev-setup-go: dev-setup-common 
+dev-setup-ubuntu-go: dev-setup-common
 	go install mvdan.cc/gofumpt@latest
 	go install golang.org/x/tools/cmd/goimports@latest
 	mkdir -p $$HOME/bin
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $$HOME/bin v2.0.2
-	@echo "✓ Go development environment ready"
+	@echo "✓ Ubuntu Go development environment ready"
 
-dev-setup-python: dev-setup-common 
+dev-setup-macos-go:
+	@if ! command -v brew >/dev/null 2>&1; then \
+		echo "ERROR: Homebrew not found. Install from https://brew.sh first."; \
+		exit 1; \
+	fi
+	brew install go golangci-lint
+	cd go && go mod download
+	go install mvdan.cc/gofumpt@latest
+	go install golang.org/x/tools/cmd/goimports@latest
+	@echo "✓ macOS Go development environment ready"
+
+dev-setup-ubuntu-python: dev-setup-common
 	sudo apt update
 	sudo apt install -y python3 python3-pip python3-venv \
 		python3-aiohttp python3-boto3 python3-google-auth python3-jwt python3-cryptography \
@@ -145,18 +164,29 @@ dev-setup-python: dev-setup-common
 		python3-google-auth-oauthlib python3-flake8 black python3-mypy python3-isort
 	@echo "Installing editable package with dev extras (pip) ..."
 	cd python && pip install -e .[dev]
-	@echo "✓ Python development environment ready (no virtualenv)"
+	@echo "✓ Ubuntu Python development environment ready (no virtualenv)"
 
-# Cloud provider specific installations
-install-aws:
-	@echo "Installing AWS CLI..."
+dev-setup-macos-python:
+	@if ! command -v brew >/dev/null 2>&1; then \
+		echo "ERROR: Homebrew not found. Install from https://brew.sh first."; \
+		exit 1; \
+	fi
+	brew install python3 pipx 
+	python3 -m pip install --upgrade pip
+	pipx ensurepath
+	python3 -m pip install --upgrade \
+		black isort flake8 mypy pytest pytest-cov pytest-asyncio aiohttp boto3 google-auth pyjwt cryptography requests google-auth-oauthlib
+	cd python && pip3 install -e .[dev]
+	@echo "✓ macOS Python development environment ready"
+
+dev-setup-aws:
 	sudo snap install aws-cli --classic
 
-install-azure:
+dev-setup-azure:
 	@echo "Installing Azure CLI..."
 	curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
-install-gcp:
+dev-setup-gcp:
 	@echo "GCP dependencies installed via python3-google-auth and python3-google-auth-oauthlib"
 
 lint: lint-go lint-python

--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,6 @@ help:
 	@echo "  make on-remote-test-go                    Run Go cloud tests only"
 	@echo "  make on-remote-test-python                Run Python cloud tests only"
 	@echo ""
-	@echo "(Legacy launch-* convenience targets removed; use explicit sequence:)"
-	@echo "  make ssh-copy-to-remote && make ssh-run-remote-tests TEST_TARGET=on-remote-test && make ssh-download-coverage && make ssh-cleanup-remote"
-	@echo "  (Or specify on-remote-test-go / on-remote-test-python for single language)"
-	@echo ""
 	@echo "  SSH Operations (for advanced usage):"
 	@echo "    make ssh-copy-to-remote                 Copy code to remote HOST"
 	@echo "    make ssh-run-remote-tests               Run TEST_TARGET on remote HOST"
@@ -116,8 +112,7 @@ on-remote-test-go: check-cloud-env
 	@echo "Environment: S2IAM_TEST_CLOUD_PROVIDER=$${S2IAM_TEST_CLOUD_PROVIDER:-<unset>}"
 	@echo "Environment: S2IAM_TEST_CLOUD_PROVIDER_NO_ROLE=$${S2IAM_TEST_CLOUD_PROVIDER_NO_ROLE:-<unset>}"
 	@echo "Environment: S2IAM_TEST_ASSUME_ROLE=$${S2IAM_TEST_ASSUME_ROLE:-<unset>}"
-	cd go && go test -v --failfast ./...
-	cd go && go test -covermode=atomic -coverprofile=coverage.out -coverpkg=github.com/singlestore-labs/singlestore-auth-iam/go/... ./...
+	cd go && go test -v -failfast -covermode=atomic -coverprofile=coverage.out -coverpkg=github.com/singlestore-labs/singlestore-auth-iam/go/... ./...
 
 on-remote-test-python: check-cloud-env
 	@echo "=== Running Python cloud tests ==="
@@ -292,7 +287,5 @@ ssh-download-coverage-python: check-host
 ssh-cleanup-remote: check-host
 	@echo "Cleaning up remote directory on $(HOST)..."
 	ssh $(SSH_OPTS) $(HOST) "rm -rf $(REMOTE_BASE_DIR)/$(UNIQUE_DIR)"
-
-## (Removed legacy launch-* targets; explicit sequence preferred for clarity and fail-fast)
 
 

--- a/go/README.md
+++ b/go/README.md
@@ -4,7 +4,7 @@
 ![Go unit tests](https://github.com/singlestore-labs/singlestore-auth-iam/actions/workflows/go.yml/badge.svg)
 [![Go report card](https://goreportcard.com/badge/github.com/singlestore-labs/singlestore-auth-iam/go)](https://goreportcard.com/report/github.com/singlestore-labs/singlestore-auth-iam/go)
 
-A Go client library for getting JWT tokens from SingleStore's IAM service when running in cloud environments (AWS, GCP, Azure).
+A Go client library for getting JWTs from SingleStore's IAM service when running in cloud environments (AWS, GCP, Azure).
 
 ## Installation
 

--- a/go/cmd/integration_test.go
+++ b/go/cmd/integration_test.go
@@ -101,7 +101,6 @@ func startServerWithRandomPort(t *testing.T, binary string, args []string) (int,
 		if time.Now().After(deadline) {
 			cleanup()
 			elapsed := time.Since(startPoll).Truncate(10 * time.Millisecond)
-			contextStr := "local"
 			return 0, nil, nil, fmt.Errorf("timed out (%s) waiting for test server startup info file (%s)", elapsed, infoFile)
 		}
 		time.Sleep(100 * time.Millisecond)

--- a/go/cmd/s2iam/main.go
+++ b/go/cmd/s2iam/main.go
@@ -89,7 +89,7 @@ func parseFlags(flagSet *flag.FlagSet, args []string) (Config, error) {
 	// Custom usage
 	flagSet.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %s [options]\n\n", args[0])
-		fmt.Fprintf(os.Stderr, "Obtain a JWT token from SingleStore IAM authentication.\n\n")
+		fmt.Fprintf(os.Stderr, "Obtain a JWT from SingleStore IAM authentication.\n\n")
 		fmt.Fprintf(os.Stderr, "Options:\n")
 		flagSet.PrintDefaults()
 		fmt.Fprintf(os.Stderr, "\nExamples:\n")

--- a/go/cmd/s2iam_test_server/README.md
+++ b/go/cmd/s2iam_test_server/README.md
@@ -1,353 +1,120 @@
-# s2iam_test_server - Test Server
+# s2iam_test_server
 
-The `s2iam_test_server` is a test server that facilitates writing and testing client implementations for SingleStore IAM authentication in various languages. It simulates the SingleStore authentication server behavior and provides flexible configuration options for testing different scenarios.
+Lightweight test server used to exercise SingleStore IAM client libraries. It issues mock JWTs, exposes a public key, records requests, and supports simple failure toggles.
 
-## Installation
+## Install
 
 ```bash
 go install github.com/singlestore-labs/singlestore-auth-iam/go/cmd/s2iam_test_server@latest
 ```
 
-## Quick Start
+## Core Usage (atomic startup + shutdown)
 
-Start the test server with default settings:
 ```bash
-s2iam_test_server
+info=$(mktemp)
+s2iam_test_server --port=0 --info-file "$info" --shutdown-on-stdin-close &
+srv_pid=$!
+while [ ! -s "$info" ]; do sleep 0.05; done
+port=$(jq -r '.server_info.port' "$info")
+echo "port=$port"
+# stop (close stdin)
+kill -0 $srv_pid 2>/dev/null && exec 3>/proc/$srv_pid/fd/0 || kill $srv_pid
 ```
 
-The server will start on port 8080 by default. Once it's fully ready to accept requests, it outputs JSON-formatted server information:
+Simpler stop alternative (may send SIGTERM if stdin trick not available):
+```bash
+kill $srv_pid
+```
+
+Info file JSON (minimal shape):
 ```json
-{
-  "server_info": {
-    "port": 8080,
-    "endpoints": {
-      "auth": "http://localhost:8080/auth/iam/:jwtType",
-      "public_key": "http://localhost:8080/info/public-key",
-      "requests": "http://localhost:8080/info/requests",
-      "health": "http://localhost:8080/health"
-    },
-    "config": {
-      "fail_verification": false,
-      "return_empty_jwt": false,
-      "return_error": false,
-      "error_code": 500,
-      "token_expiry": "1h0m0s"
-    }
-  }
-}
+{ "server_info": { "port": 12345, "pid": 4242, "started_at": "RFC3339" } }
 ```
 
-**Note**: The server automatically performs a health check on itself before printing this JSON output, ensuring that when you parse this information, the server is guaranteed to be ready to accept requests.
+Wait until the info file exists and is non‑empty, then read the port.
 
 ## Endpoints
 
-### Authentication Endpoint
-- **URL**: `/auth/iam/{jwtType}`
-- **Method**: GET/POST
-- **Parameters**: 
-  - `workspaceGroupID` (query parameter)
-  - `jwtType` (path parameter): Type of JWT to generate (e.g., "database", "api")
-- **Response**: JSON object with a `jwt` field containing the generated JWT
-  ```json
-  {
-    "jwt": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
-  }
-  ```
+| Path | Purpose |
+|------|---------|
+| `/auth/iam/{jwtType}` | Return signed JWT (query: `workspaceGroupID`) |
+| `/info/public-key` | RSA public key (PEM) |
+| `/info/requests` | JSON log of received requests |
+| `/health` | Health probe (JSON) |
 
-### Public Key Endpoint
-- **URL**: `/info/public-key`
-- **Method**: GET
-- **Response**: RSA public key in PEM format (text/plain)
-  ```
-  -----BEGIN RSA PUBLIC KEY-----
-  MIIBCgKCAQEA...
-  -----END RSA PUBLIC KEY-----
-  ```
-
-### Request Log Endpoint
-- **URL**: `/info/requests`
-- **Method**: GET
-- **Response**: JSON array of all received requests with details
-
-### Health Check Endpoint
-- **URL**: `/health`
-- **Method**: GET
-- **Response**: JSON object with server status
-  ```json
-  {
-    "status": "healthy",
-    "time": "2025-01-15T10:30:00Z",
-    "config": {
-      "port": 8080,
-      "failVerification": false,
-      "returnEmptyJWT": false,
-      "returnError": false
-    }
-  }
-  ```
-
-## Configuration Options
+## Flags
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--port` | 8080 | Port to listen on (use 0 for random port) |
-| `--key-size` | 2048 | RSA key size in bits |
-| `--fail-verification` | false | Fail verification for all requests |
-| `--return-empty-jwt` | false | Return empty JWT in response |
-| `--return-error` | false | Return an error response |
-| `--error-code` | 500 | HTTP error code to return (when --return-error) |
-| `--error-message` | "Internal Server Error" | Error message to return |
-| `--required-audience` | "" | Required audience value for GCP tokens |
-| `--azure-tenant` | "common" | Azure tenant ID |
-| `--token-expiry` | 1h | Token expiry duration |
-| `--allowed-audiences` | "https://authsvc.singlestore.com" | Comma-separated list of allowed audiences |
-| `--verbose` | false | Enable verbose logging |
+| `--port` | 8080 | Listen port (0 = random) |
+| `--key-size` | 2048 | RSA key size bits |
+| `--fail-verification` | false | Force verification failure responses |
+| `--return-empty-jwt` | false | Return empty JWT string |
+| `--return-error` | false | Always return error response |
+| `--error-code` | 500 | Error code when returning error |
+| `--error-message` | Internal Server Error | Error message when returning error |
+| `--required-audience` | (empty) | Enforce GCP audience claim |
+| `--azure-tenant` | common | Azure tenant id |
+| `--token-expiry` | 1h | JWT lifetime |
+| `--allowed-audiences` | https://authsvc.singlestore.com | Comma separated audiences |
+| `--verbose` | false | Verbose logging |
+| `--info-file` | (empty) | Atomic JSON server info path |
+| `--shutdown-on-stdin-close` | false | Graceful shutdown when stdin reaches EOF |
 
-## Testing Scenarios
-
-### Basic Usage
-
-```bash
-# Start with default configuration
-s2iam_test_server
-
-# Use a random port
-s2iam_test_server --port=0
-
-# Enable verbose logging
-s2iam_test_server --verbose
-```
-
-### Error Simulation
-
-```bash
-# Simulate verification failure
-s2iam_test_server --fail-verification
-
-# Return empty JWT
-s2iam_test_server --return-empty-jwt
-
-# Return custom error
-s2iam_test_server --return-error --error-code=503 --error-message="Service unavailable"
-```
-
-### Cloud Provider Configuration
-
-```bash
-# Require specific GCP audience
-s2iam_test_server --required-audience=https://myapp.example.com
-
-# Configure Azure tenant
-s2iam_test_server --azure-tenant=12345678-1234-1234-1234-123456789012
-
-# Set custom allowed audiences
-s2iam_test_server --allowed-audiences=https://authsvc.singlestore.com,https://myapp.com
-```
-
-## Client Integration Examples
-
-### Python Example
+## Python snippet
 
 ```python
-import requests
-import subprocess
-import json
+import subprocess, json, os, time, tempfile
 
-# Start the test server with a random port
-server = subprocess.Popen(['s2iam_test_server', '--port=0'], 
-                         stdout=subprocess.PIPE,
-                         stderr=subprocess.PIPE)
-
-# Read and parse the server output
-# The server waits until it's ready before printing, so no sleep needed
-output_line = server.stdout.readline()
-server_info = json.loads(output_line)['server_info']
-port = server_info['port']
-
-try:
-    # For AWS IAM authentication
-    headers = {
-        'X-Amz-Security-Token': 'your-session-token',
-        'X-Amz-Date': '20250113T123456Z',
-        'Authorization': 'AWS4-HMAC-SHA256 Credential=...'
-    }
-    
-    response = requests.post(
-        f'http://localhost:{port}/auth/iam/database',
-        headers=headers,
-        params={'workspaceGroupID': 'test-workspace'}
-    )
-    
-    jwt = response.json()['jwt']
-    print(f"Got JWT: {jwt}")
-    
-    # Get the public key for JWT verification
-    public_key_response = requests.get(f'http://localhost:{port}/info/public-key')
-    public_key_pem = public_key_response.text
-    
-finally:
-    server.terminate()
+with tempfile.TemporaryDirectory() as tmp:
+  info = os.path.join(tmp, 'srv.json')
+  proc = subprocess.Popen([
+    's2iam_test_server','--port=0','--info-file',info
+  ])
+  for _ in range(300):
+    if os.path.exists(info) and os.path.getsize(info)>0: break
+    time.sleep(0.05)
+  port = json.load(open(info))['server_info']['port']
+  print('port', port)
+  # run tests using port
+  # optional: proc.terminate() or proc.stdin.close() to shut down server early
 ```
 
-### JavaScript/Node.js Example
-
-```javascript
-const { spawn } = require('child_process');
-
-// Start the test server
-const server = spawn('s2iam_test_server', ['--port=0']);
-
-// Parse server output to get port
-// The server is ready when it prints the JSON output
-server.stdout.once('data', async (data) => {
-    const output = data.toString();
-    const serverInfo = JSON.parse(output).server_info;
-    const port = serverInfo.port;
-    
-    try {
-        // For GCP authentication
-        const url = new URL(`http://localhost:${port}/auth/iam/api`);
-        url.searchParams.set('workspaceGroupID', 'test-workspace');
-        
-        const response = await fetch(url, {
-            method: "POST",
-            headers: {
-                'Metadata-Flavor': 'Google',
-                'Authorization': 'Bearer gcp-token'
-            }
-        });
-        
-        const jwt = (await response.json()).jwt;
-        console.log(`Got JWT: ${jwt}`);
-        
-    } finally {
-        server.kill();
-    }
-});
-```
-
-### Go Example
+## Go snippet
 
 ```go
-package main
-
-import (
-    "context"
-    "encoding/json"
-    "fmt"
-    "net/http"
-    "os/exec"
-    "time"
-)
-
-func main() {
-    // Start test server
-    cmd := exec.Command("s2iam_test_server", "--port=0")
-    stdout, _ := cmd.StdoutPipe()
-    _ = cmd.Start()
-    
-    // Parse server info
-    var serverInfo struct {
-        ServerInfo struct {
-            Port int `json:"port"`
-        } `json:"server_info"`
-    }
-    
-    decoder := json.NewDecoder(stdout)
-    _ = decoder.Decode(&serverInfo)
-    port := serverInfo.ServerInfo.Port
-    
-    // Make authentication request
-    client := &http.Client{Timeout: 5 * time.Second}
-    
-    req, _ := http.NewRequest("POST", 
-        fmt.Sprintf("http://localhost:%d/auth/iam/database", port), 
-        nil)
-    
-    // Add Azure headers
-    req.Header.Set("X-Ms-Identity-Provider", "azure")
-    req.Header.Set("Authorization", "Bearer azure-token")
-    
-    resp, _ := client.Do(req)
-    defer resp.Body.Close()
-    
-    var result map[string]string
-    _ = json.NewDecoder(resp.Body).Decode(&result)
-    
-    fmt.Printf("Got JWT: %s\n", result["jwt"])
-    
-    // Cleanup
-    _ = cmd.Process.Kill()
+cmd := exec.Command("s2iam_test_server","--port=0","--info-file","info.json")
+_ = cmd.Start()
+for {
+  b, err := os.ReadFile("info.json")
+  if err == nil && len(b) > 0 { break }
+  time.Sleep(50 * time.Millisecond)
 }
+var out struct { ServerInfo struct { Port int `json:"port"` } `json:"server_info"` }
+f, _ := os.Open("info.json"); _ = json.NewDecoder(f).Decode(&out); f.Close()
+fmt.Println("port", out.ServerInfo.Port)
+// run tests using out.ServerInfo.Port
+// optional: close(cmd.Stdin) to shut down server
 ```
 
-## Docker Usage
+## Error simulation
 
-Create a Dockerfile for containerized testing:
-
-```dockerfile
-FROM golang:1.21-alpine
-WORKDIR /app
-COPY . .
-RUN go build -o s2iam_test_server ./cmd/s2iam_test_server
-EXPOSE 8080
-CMD ["./s2iam_test_server"]
-```
-
-Build and run:
+Examples:
 ```bash
-docker build -t s2iam-test-server .
-docker run -p 8080:8080 s2iam-test-server
-
-# With custom configuration
-docker run -p 8080:8080 s2iam-test-server \
-    --verbose \
-    --token-expiry=30m \
-    --allowed-audiences=https://myapp.com
+s2iam_test_server --fail-verification --info-file f &
+s2iam_test_server --return-empty-jwt --info-file f &
+s2iam_test_server --return-error --error-code=503 --error-message="Service unavailable" --info-file f &
 ```
 
-## Expected Headers by Provider
+## Request log
 
-When testing authentication, use the appropriate headers for each cloud provider:
+`/info/requests` returns JSON array of received requests (method, path, headers, time).
 
-### AWS
-- `X-Amz-Security-Token`: Session token (if using temporary credentials)
-- `X-Amz-Date`: Request timestamp
-- `Authorization`: AWS Signature v4 authorization header
+## Public key
 
-### GCP
-- `Metadata-Flavor`: Should be "Google"
-- `Authorization`: Bearer token with GCP access token
+`/info/public-key` returns PEM you can feed into JWT verification.
 
-### Azure
-- `X-Ms-Identity-Provider`: Should be "azure"
-- `Authorization`: Bearer token with Azure access token
+## Notes
 
-## JWT Structure
-
-The generated JWT contain the following claims:
-- `sub`: Cloud provider identifier
-- `provider`: Cloud provider name (aws, gcp, azure)
-- `accountID`: Account/project ID
-- `region`: Region (if applicable)
-- `resourceType`: Resource type
-- `jwtType`: Type specified in the URL path
-- `iat`: Issued at timestamp
-- `exp`: Expiration timestamp
-
-## Tips for Testing
-
-1. **Random Port Selection**: Use `--port=0` to let the server choose a random available port, useful for parallel testing.
-
-2. **No Wait Required**: The server performs a self-health check before printing the JSON output, guaranteeing it's ready to accept requests. Tests can parse the JSON and immediately start making requests without any additional wait time.
-
-3. **Parse Server Output**: The server outputs JSON-formatted information when ready, making it easy to programmatically determine the port and endpoints.
-
-4. **Verbose Logging**: Use `--verbose` to see detailed request processing information during development.
-
-5. **Request Logging**: Use the `/info/requests` endpoint to inspect all requests received by the server, helpful for debugging client implementations.
-
-6. **JWT Verification**: Retrieve the public key from `/info/public-key` to verify the generated JWTs in your tests.
-
-7. **Error Simulation**: Use error flags to test your client's error handling capabilities.
+Use `--port=0` for parallel test runs. Always prefer `--info-file` + polling over stdout parsing.
 

--- a/go/cmd/s2iam_test_server/README.md
+++ b/go/cmd/s2iam_test_server/README.md
@@ -47,7 +47,7 @@ The server will start on port 8080 by default. Once it's fully ready to accept r
 - **Parameters**: 
   - `workspaceGroupID` (query parameter)
   - `jwtType` (path parameter): Type of JWT to generate (e.g., "database", "api")
-- **Response**: JSON object with a `jwt` field containing the generated JWT token
+- **Response**: JSON object with a `jwt` field containing the generated JWT
   ```json
   {
     "jwt": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
@@ -323,9 +323,9 @@ When testing authentication, use the appropriate headers for each cloud provider
 - `X-Ms-Identity-Provider`: Should be "azure"
 - `Authorization`: Bearer token with Azure access token
 
-## JWT Token Structure
+## JWT Structure
 
-The generated JWT tokens contain the following claims:
+The generated JWT contain the following claims:
 - `sub`: Cloud provider identifier
 - `provider`: Cloud provider name (aws, gcp, azure)
 - `accountID`: Account/project ID

--- a/go/cmd/s2iam_test_server/main.go
+++ b/go/cmd/s2iam_test_server/main.go
@@ -9,10 +9,12 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -36,6 +38,8 @@ type Config struct {
 	AllowedAudiences []string
 	Verbose          bool
 	Timeout          time.Duration
+	InfoFile         string // Path to atomically written server info
+	ShutdownOnStdin  bool   // Graceful shutdown when stdin closes
 }
 
 // Standardized timeouts (avoid magic numbers)
@@ -122,6 +126,8 @@ func parseFlags() Config {
 	flag.StringVar(&allowedAudiencesStr, "allowed-audiences", "https://authsvc.singlestore.com", "Comma-separated list of allowed audiences")
 	flag.BoolVar(&config.Verbose, "verbose", false, "Enable verbose logging")
 	flag.DurationVar(&config.Timeout, "timeout", 0, "Auto-shutdown timeout (0 = no timeout)")
+	flag.StringVar(&config.InfoFile, "info-file", "", "Write server info JSON atomically to this file")
+	flag.BoolVar(&config.ShutdownOnStdin, "shutdown-on-stdin-close", false, "Shutdown when stdin closes (for test cleanup)")
 
 	flag.Parse()
 
@@ -169,6 +175,41 @@ type logger struct{}
 
 func (logger) Logf(format string, args ...any) {
 	log.Printf("[verifier] "+format, args...)
+}
+
+// writeAtomic writes data to filename atomically via temp file + rename.
+func writeAtomic(filename string, data []byte, perm os.FileMode) (err error) {
+	if filename == "" {
+		return fmt.Errorf("empty filename")
+	}
+	dir := filepath.Dir(filename)
+	base := filepath.Base(filename)
+	var tmp *os.File
+	tmp, err = os.CreateTemp(dir, base+".tmp-*")
+	if err != nil {
+		return
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		if err != nil { // only cleanup on failure
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if _, err = tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return
+	}
+	// fsync omitted (tests only); atomic rename ensures visibility boundary
+	if err = tmp.Close(); err != nil {
+		return
+	}
+	if perm != 0 {
+		if err = os.Chmod(tmpName, perm); err != nil {
+			return
+		}
+	}
+	err = os.Rename(tmpName, filename)
+	return
 }
 
 // Run starts the test server
@@ -278,10 +319,12 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 ServerReady:
 
-	// Output server info in JSON format for easy parsing by tests
+	// Build server info
 	serverInfo := map[string]interface{}{
 		"server_info": map[string]interface{}{
-			"port": actualPort,
+			"port":       actualPort,
+			"pid":        os.Getpid(),
+			"started_at": time.Now().UTC().Format(time.RFC3339Nano),
 			"endpoints": map[string]string{
 				"auth":       fmt.Sprintf("http://localhost:%d/auth/iam/:jwtType", actualPort),
 				"public_key": fmt.Sprintf("http://localhost:%d/info/public-key", actualPort),
@@ -297,13 +340,34 @@ ServerReady:
 			},
 		},
 	}
-
-	// Output as JSON
 	jsonInfo, err := json.MarshalIndent(serverInfo, "", "  ")
 	if err != nil {
-		log.Fatalf("Warning: Failed to marshal server info to JSON: %v", err)
-	} else {
+		return fmt.Errorf("failed to marshal server info: %w", err)
+	}
+	if s.config.InfoFile == "" { // Only emit to stdout when no file requested
 		fmt.Println(string(jsonInfo))
+	} else {
+		if err := writeAtomic(s.config.InfoFile, jsonInfo, 0o644); err != nil {
+			return fmt.Errorf("write info file: %w", err)
+		}
+		log.Printf("info file written: %s", s.config.InfoFile)
+	}
+	// Optional stdin watcher
+	if s.config.ShutdownOnStdin {
+		// Consume all stdin until EOF (or read error) then trigger shutdown.
+		// Using io.Copy with a large internal buffer avoids pathological byte-by-byte reads
+		// if input is accidentally written to stdin.
+		go func() {
+			_, err := io.Copy(io.Discard, os.Stdin)
+			if err != nil && err != io.EOF {
+				log.Printf("stdin copy error: %v; shutting down", err)
+			} else {
+				log.Printf("stdin closed; shutting down")
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), serverShutdownTimeout)
+			defer cancel()
+			_ = httpServer.Shutdown(ctx)
+		}()
 	}
 
 	// Wait for the server to complete (or error)

--- a/go/cmd/s2iam_test_server/main.go
+++ b/go/cmd/s2iam_test_server/main.go
@@ -187,7 +187,7 @@ func writeAtomic(filename string, data []byte, perm os.FileMode) (err error) {
 	var tmp *os.File
 	tmp, err = os.CreateTemp(dir, base+".tmp-*")
 	if err != nil {
-		return
+		return err
 	}
 	tmpName := tmp.Name()
 	defer func() {
@@ -197,19 +197,19 @@ func writeAtomic(filename string, data []byte, perm os.FileMode) (err error) {
 	}()
 	if _, err = tmp.Write(data); err != nil {
 		_ = tmp.Close()
-		return
+		return err
 	}
 	// fsync omitted (tests only); atomic rename ensures visibility boundary
 	if err = tmp.Close(); err != nil {
-		return
+		return err
 	}
 	if perm != 0 {
 		if err = os.Chmod(tmpName, perm); err != nil {
-			return
+			return err
 		}
 	}
 	err = os.Rename(tmpName, filename)
-	return
+	return err
 }
 
 // Run starts the test server

--- a/go/s2iam/api.go
+++ b/go/s2iam/api.go
@@ -151,7 +151,14 @@ func detectProviderImpl(ctx context.Context, options detectProviderOptions) (Clo
 		}
 	}
 
-	// Set up timeout context
+	// First attempt fast in-process detection (no network). Return immediately on success.
+	for _, client := range options.clients {
+		if err := client.FastDetect(); err == nil {
+			return client, nil
+		}
+	}
+
+	// Set up timeout context for full detection
 	var cancel func()
 	if options.timeout > 0 {
 		ctx, cancel = context.WithTimeout(ctx, options.timeout)

--- a/go/s2iam/azure/client.go
+++ b/go/s2iam/azure/client.go
@@ -361,7 +361,7 @@ func (c *AzureClient) GetIdentityHeaders(ctx context.Context, additionalParams m
 	return headers, identity, nil
 }
 
-// getIdentityFromToken parses the JWT token to extract identity information
+// getIdentityFromToken parses the JWT to extract identity information
 func (c *AzureClient) getIdentityFromToken(ctx context.Context, tokenString string) (*models.CloudIdentity, error) {
 	// Parse the token without validation to extract claims
 	parts := strings.Split(tokenString, ".")

--- a/go/s2iam/azure/client.go
+++ b/go/s2iam/azure/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -24,10 +25,6 @@ const (
 	// Azure constants
 	azureAPIVersion     = "2018-02-01"
 	azureResourceServer = "https://management.azure.com/"
-
-	// Timing constants
-	azureRateLimitBaseDelay  = 100 * time.Millisecond
-	azureRateLimitMaxRetries = 3
 )
 
 // AzureClient implements the CloudProviderClient interface for Azure
@@ -52,6 +49,21 @@ func (c *AzureClient) copy() *AzureClient {
 	}
 }
 
+// FastDetect performs in-process detection without network I/O.
+func (c *AzureClient) FastDetect() error {
+	if os.Getenv("AZURE_FEDERATED_TOKEN_FILE") != "" || (os.Getenv("AZURE_CLIENT_ID") != "" && os.Getenv("AZURE_TENANT_ID") != "") ||
+		os.Getenv("AZURE_ENV") != "" || os.Getenv("MSI_ENDPOINT") != "" || os.Getenv("IDENTITY_ENDPOINT") != "" {
+		c.mu.Lock()
+		c.detected = true
+		c.mu.Unlock()
+		if c.logger != nil {
+			c.logger.Logf("Azure FastDetect - Detected via environment variables")
+		}
+		return nil
+	}
+	return errors.WithStack(models.ErrNoCloudProviderDetected)
+}
+
 // NewClient returns a new Azure client instance
 func NewClient(logger models.Logger) models.CloudProviderClient {
 	return &AzureClient{
@@ -59,7 +71,9 @@ func NewClient(logger models.Logger) models.CloudProviderClient {
 	}
 }
 
-// Detect tests if we are executing within Azure and if a managed identity is available
+// Detect performs network-inclusive detection. It assumes FastDetect may have already
+// succeeded based on local workload identity / env indicators. If c.detected is true
+// upon entry, it returns immediately.
 func (c *AzureClient) Detect(ctx context.Context) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -73,14 +87,7 @@ func (c *AzureClient) Detect(ctx context.Context) error {
 		c.logger.Logf("Azure Detection - Starting detection")
 	}
 
-	// Fast path: Check Azure environment variable
-	if os.Getenv("AZURE_ENV") != "" {
-		if c.logger != nil {
-			c.logger.Logf("Azure Detection - Found AZURE_ENV environment variable")
-		}
-		c.detected = true
-		return nil
-	}
+	// Environment-only paths handled by FastDetect; continue with metadata probing.
 
 	// Try to access the Azure metadata service
 	if c.logger != nil {
@@ -126,80 +133,102 @@ func (c *AzureClient) Detect(ctx context.Context) error {
 	// Try to get a token to verify identity is available with retry for rate limiting
 	tokenURL := fmt.Sprintf("%s?api-version=%s&resource=%s", azureMetadataURL, azureAPIVersion, azureResourceServer)
 
-	// Retry loop for rate limiting (HTTP 429)
-	maxRetries := azureRateLimitMaxRetries
-	baseDelay := azureRateLimitBaseDelay
-
-	for attempt := 0; attempt <= maxRetries; attempt++ {
-		tokenReq, err := http.NewRequestWithContext(ctx, http.MethodGet, tokenURL, nil)
-		if err != nil {
-			if c.logger != nil {
-				c.logger.Logf("Azure Detection - Failed to create token request: %v", err)
-			}
-			return errors.Errorf("failed to create Azure token request: %w", err)
+	// Single attempt token request (no retry loop; keep detection fast/deterministic)
+	tokenReq, err := http.NewRequestWithContext(ctx, http.MethodGet, tokenURL, nil)
+	if err != nil {
+		if c.logger != nil {
+			c.logger.Logf("Azure Detection - Failed to create token request: %v", err)
 		}
-		tokenReq.Header.Set("Metadata", "true")
+		return errors.Errorf("failed to create Azure token request: %w", err)
+	}
+	tokenReq.Header.Set("Metadata", "true")
 
-		tokenResp, err := client.Do(tokenReq)
+	// Configurable exponential backoff: defaults tuned for robustness over minimal latency.
+	// Defaults: 6 attempts (50,100,200,400,800,1600ms delays) ~3.15s total delay ceiling + network time.
+	const (
+		defaultMIMaxAttempts = 6
+		defaultMIBaseBackoff = 50 * time.Millisecond
+	)
+	maxAttempts := defaultMIMaxAttempts
+	if v := os.Getenv("S2IAM_AZURE_MI_RETRIES"); v != "" { // allow increasing attempts in production
+		if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= 20 { // hard cap 20 to avoid runaway
+			maxAttempts = n
+		}
+	}
+	baseBackoff := defaultMIBaseBackoff
+	if v := os.Getenv("S2IAM_AZURE_MI_BACKOFF_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 && n < 5000 { // cap single backoff base to <5s
+			baseBackoff = time.Duration(n) * time.Millisecond
+		}
+	}
+
+	if c.logger != nil {
+		c.logger.Logf("Azure Detection - Managed identity token attempts=%d base_backoff_ms=%d", maxAttempts, baseBackoff/time.Millisecond)
+	}
+
+	var lastStatus int
+	for attempt := 0; attempt < maxAttempts; attempt++ { // exponential backoff for transient throttle
+		resp, err := client.Do(tokenReq)
 		if err != nil {
 			if c.logger != nil {
-				c.logger.Logf("Azure Detection - Token request failed: %v", err)
+				c.logger.Logf("Azure Detection - Token request error (attempt %d): %v", attempt+1, err)
 			}
 			return models.ErrProviderDetectedNoIdentity.Errorf("Azure detected but no managed identity available: %s", err)
 		}
+		lastStatus = resp.StatusCode
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
 
-		defer func() {
-			_ = tokenResp.Body.Close()
-		}()
-
-		// Success case
-		if tokenResp.StatusCode == http.StatusOK {
-			break
-		}
-
-		// Rate limiting case - retry with exponential backoff
-		if tokenResp.StatusCode == 429 && attempt < maxRetries {
-			delay := baseDelay * time.Duration(1<<attempt) // Exponential backoff: 100ms, 200ms, 400ms
+		if resp.StatusCode == http.StatusOK {
+			// Success
+			c.detected = true
 			if c.logger != nil {
-				c.logger.Logf("Azure Detection - Rate limited (429), retrying in %v (attempt %d/%d)", delay, attempt+1, maxRetries+1)
+				c.logger.Logf("Azure Detection - Successfully detected Azure environment with managed identity")
 			}
-
-			select {
-			case <-time.After(delay):
-				continue
-			case <-ctx.Done():
-				return ctx.Err()
-			}
+			return nil
 		}
 
-		// Handle other error cases
-		bodyBytes, _ := io.ReadAll(tokenResp.Body)
 		var errorResponse struct {
 			Error            string `json:"error"`
 			ErrorDescription string `json:"error_description"`
 		}
+		_ = json.Unmarshal(bodyBytes, &errorResponse)
 
-		if json.Unmarshal(bodyBytes, &errorResponse) == nil {
-			if errorResponse.Error == "invalid_request" && strings.Contains(errorResponse.ErrorDescription, "Identity not found") {
-				if c.logger != nil {
-					c.logger.Logf("Azure Detection - No managed identity found")
-				}
-				return models.ErrProviderDetectedNoIdentity.Errorf("Azure detected but no managed identity available: invalid token response")
+		if resp.StatusCode == http.StatusTooManyRequests { // 429 throttle
+			if c.logger != nil {
+				c.logger.Logf("Azure Detection - Throttled (429) on attempt %d/%d", attempt+1, maxAttempts)
 			}
+			if attempt < maxAttempts-1 { // schedule exponential backoff retry
+				delay := baseBackoff << attempt
+				if c.logger != nil {
+					c.logger.Logf("Azure Detection - Backing off %s before retry", delay)
+				}
+				select {
+				case <-ctx.Done():
+					return models.ErrProviderDetectedNoIdentity.Errorf("Azure detected but managed identity throttled: %v", ctx.Err())
+				case <-time.After(delay):
+					continue
+				}
+			}
+			return models.ErrProviderDetectedNoIdentity.Errorf("Azure detected but managed identity throttled (429)")
+		}
+
+		if errorResponse.Error == "invalid_request" && strings.Contains(errorResponse.ErrorDescription, "Identity not found") {
+			if c.logger != nil {
+				c.logger.Logf("Azure Detection - No managed identity found")
+			}
+			return models.ErrProviderDetectedNoIdentity.Errorf("Azure detected but no managed identity available: invalid token response")
 		}
 
 		if c.logger != nil {
-			c.logger.Logf("Azure Detection - Token request returned status %d", tokenResp.StatusCode)
+			c.logger.Logf("Azure Detection - Token request status %d", resp.StatusCode)
 		}
-		return models.ErrProviderDetectedNoIdentity.Errorf("Azure detected but managed identity check failed: %d", tokenResp.StatusCode)
+		// Non-success status: classify as provider detected, identity unavailable
+		return models.ErrProviderDetectedNoIdentity.Errorf("Azure detected but managed identity check failed: %d", resp.StatusCode)
 	}
 
-	// We've confirmed we're on Azure and have a managed identity
-	c.detected = true
-	if c.logger != nil {
-		c.logger.Logf("Azure Detection - Successfully detected Azure environment with managed identity")
-	}
-	return nil
+	// Loop exhausted without success
+	return models.ErrProviderDetectedNoIdentity.Errorf("Azure detected but managed identity unavailable (last status %d)", lastStatus)
 }
 
 // GetType returns the cloud provider type

--- a/go/s2iam/jwt.go
+++ b/go/s2iam/jwt.go
@@ -17,8 +17,8 @@ const (
 	// defaultServer is the default authentication server endpoint
 	defaultServer = "https://authsvc.singlestore.com/auth/iam/:jwtType"
 
-	// defaultHTTPTimeout controls outbound calls to the auth service
-	defaultHTTPTimeout = 10 * time.Second
+	// defaultHTTPClientTimeout is used for outbound auth server requests
+	defaultHTTPClientTimeout = 10 * time.Second
 )
 
 // JWTOptions are used to configure how to get JWTs
@@ -149,7 +149,7 @@ func getJWT(ctx context.Context, defaultOpts jwtOptions, opts []JWTOption) (stri
 	}
 
 	// Send request
-	httpClient := &http.Client{Timeout: defaultHTTPTimeout}
+	httpClient := &http.Client{Timeout: defaultHTTPClientTimeout}
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return "", errors.Errorf("error calling authentication server: %w", err)

--- a/go/s2iam/models/client.go
+++ b/go/s2iam/models/client.go
@@ -60,8 +60,15 @@ const (
 type CloudProviderClient interface {
 	// Detect tests if we are executing within this cloud provider. No
 	// assumption of how is made -- we could also be inside K8s. For
-	// AWS, we could be on Lambda or EC2.
+	// AWS, we could be on Lambda or EC2. Detect assumes that FastDetect() has
+	// already been called and will return early if FastDetect succeeded.
 	Detect(ctx context.Context) error
+
+	// FastDetect performs only in-process, non-network detection (environment variables,
+	// credential file presence). It must not perform any I/O that can block. It returns
+	// nil if detection succeeded, ErrNoCloudProviderDetected (wrapped) if not detected,
+	// and any other error for unexpected conditions.
+	FastDetect() error
 
 	// GetType returns the cloud provider type as a string
 	GetType() CloudProviderType

--- a/go/s2iam/s2iam_test.go
+++ b/go/s2iam/s2iam_test.go
@@ -806,11 +806,8 @@ func TestCloudProviderNoRole(t *testing.T) {
 // Test with environment variable for debugging
 func TestWithDebugging(t *testing.T) {
 	// Cannot use t.Parallel() - modifies global environment variable S2IAM_DEBUGGING
-	// Set debugging env var
-	_ = os.Setenv("S2IAM_DEBUGGING", "true")
-	defer func() {
-		_ = os.Unsetenv("S2IAM_DEBUGGING")
-	}()
+	// Set debugging env var using t.Setenv for automatic cleanup
+	t.Setenv("S2IAM_DEBUGGING", "true")
 
 	// This should create a logger automatically
 	client, err := s2iam.DetectProvider(context.Background(),

--- a/python/README.md
+++ b/python/README.md
@@ -176,24 +176,40 @@ The library defines several specific exceptions:
 
 ### Testing
 
-The library includes comprehensive tests that use the Go test server for integration testing:
+Tests use the Go test server (`s2iam_test_server`) started with the new `--info-file` flag for deterministic startup (no stdout JSON parsing). Async tests require `pytest-asyncio` which is part of the `dev` extras.
 
 ```bash
-# Run tests
+# Install with dev dependencies
+pip install -e .[dev]
+
+# Run full test suite (cloud‑dependent tests skip outside cloud VMs)
 pytest
 
-# Run tests with coverage
+# Coverage
 pytest --cov=s2iam --cov-report=html
+
+# Example: Just integration tests
+pytest -k integration
+```
+
+Manual server run example (atomic startup):
+
+```bash
+go build -o s2iam_test_server ../go/cmd/s2iam_test_server
+tmpfile=$(mktemp)
+./s2iam_test_server --port=0 --info-file "$tmpfile" --shutdown-on-stdin-close &
+while [ ! -s "$tmpfile" ]; do sleep 0.05; done
+jq . "$tmpfile"
 ```
 
 ### Code Quality
 
 ```bash
-# Format code
+# Format
 black src tests
 isort src tests
 
-# Lint
+# Static checks
 flake8 src tests
 mypy src
 ```

--- a/python/example.py
+++ b/python/example.py
@@ -2,7 +2,7 @@
 """
 Example usage of the s2iam Python library.
 
-This script demonstrates how to get a JWT token from SingleStore's IAM service.
+This script demonstrates how to get a JWT from SingleStore's IAM service.
 """
 
 import asyncio
@@ -15,19 +15,19 @@ async def main():
     print("=" * 40)
 
     try:
-        # Simple JWT token request for database access with workspace group ID
-        jwt_token = await s2iam.get_jwt_database("example-workspace-group-id")
-        print(f"✓ Successfully got database JWT token: {jwt_token[:20]}...")
+        # Simple JWT request for database access with workspace group ID
+        token = await s2iam.get_jwt_database("example-workspace-group-id")
+        print(f"✓ Successfully got database JWT: {token[:20]}...")
 
-        # JWT token for database access without workspace group ID
-        jwt_token_no_workspace = await s2iam.get_jwt_database()
+        # JWT for database access without workspace group ID
+        token_no_workspace = await s2iam.get_jwt_database()
         print(
-            f"✓ Successfully got database JWT token (no workspace): {jwt_token_no_workspace[:20]}..."
+            f"✓ Successfully got database JWT (no workspace): {token_no_workspace[:20]}..."
         )
 
-        # JWT token for API gateway access
+        # JWT for API gateway access
         api_jwt = await s2iam.get_jwt_api()
-        print(f"✓ Successfully got API JWT token: {api_jwt[:20]}...")
+        print(f"✓ Successfully got API JWT: {api_jwt[:20]}...")
 
     except s2iam.CloudProviderNotFound:
         print("❌ Not running in a supported cloud environment")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -89,6 +89,11 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 strict_equality = true
 
+[[tool.mypy.overrides]]
+# Narrow suppression: ignore missing type stubs only for boto3 and its core companions
+module = ["boto3", "botocore", "s3transfer"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 minversion = "7.0"
 testpaths = ["tests"]

--- a/python/src/s2iam/gcp/__init__.py
+++ b/python/src/s2iam/gcp/__init__.py
@@ -114,7 +114,8 @@ class GCPClient(CloudProviderClient):
         cred_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
         if cred_path and os.path.isfile(cred_path):
             try:  # noqa: BLE001
-                content = open(cred_path, "r", encoding="utf-8").read(4096)
+                with open(cred_path, "r", encoding="utf-8") as f:
+                    content = f.read(4096)
                 if '"type"' in content and '"external_account"' in content:
                     self._log("FastDetect: external_account credentials present")
                     self._detected = True

--- a/python/src/s2iam/gcp/__init__.py
+++ b/python/src/s2iam/gcp/__init__.py
@@ -4,9 +4,6 @@ Google Cloud Platform provider client implementation.
 
 import asyncio
 import os
-import socket
-import urllib.error
-import urllib.request
 from typing import Any, Optional
 
 import aiohttp
@@ -37,60 +34,100 @@ class GCPClient(CloudProviderClient):
             self._logger.log(f"GCP: {message}")
 
     async def detect(self) -> None:
-        """Detect if running on GCP (matches Go implementation)."""
-        self._log("Starting GCP detection")
-
-        # Fast path: Check if GCE_METADATA_HOST environment variable is set
-        if os.environ.get("GCE_METADATA_HOST"):
-            self._log("Found GCE_METADATA_HOST environment variable")
-            # When env var is set, we need to verify identity access (strict check)
-            try:
-                await self._verify_metadata_access()
-                self._log("GCP identity metadata access verified")
-                self._detected = True
-                return
-            except Exception:
-                self._log("Metadata service available but no identity access")
-                raise ProviderIdentityUnavailable("GCP metadata available but no identity access")
-
-        # Try to access GCP metadata service directly
-        self._log("Trying metadata service")
-        try:
-            # Use urllib with explicit timeout (matches Go's http.Client{Timeout: 3 * time.Second})
-            def sync_check() -> bool:
-                req = urllib.request.Request(
-                    "http://metadata.google.internal/computeMetadata/v1/instance/id",
-                    headers={"Metadata-Flavor": "Google"},
-                )
-                # Set socket timeout to match Go implementation
-                socket.setdefaulttimeout(3.0)
-                try:
-                    with urllib.request.urlopen(req, timeout=3.0) as response:
-                        if response.status == 200:
-                            return True
-                        else:
-                            raise Exception(f"Metadata service returned status {response.status}")
-                finally:
-                    socket.setdefaulttimeout(None)  # Reset to default
-
-            # Run sync operation in executor to avoid blocking event loop
-            loop = asyncio.get_event_loop()
-            await loop.run_in_executor(None, sync_check)
-
-            self._log("Successfully detected GCP environment")
-            self._detected = True
+        """Detect if running on GCP (full phase)."""
+        self._log("Starting GCP detection (full phase)")
+        if self._detected:
             return
 
-        except Exception as e:
-            error_msg = str(e) if str(e) else f"{type(e).__name__}"
-            self._log(f"Metadata service error: {error_msg}")
+        # IMPORTANT (future maintainer / future-me): Do NOT add retries here unless you can
+        # produce a reproducible, provider-side behavioral change that: (a) manifests as
+        # a transient failure on the very first metadata probe AND (b) becomes a success
+        # within <1s WITHOUT any configuration / environment change. Historical context:
+        # A GCP detection timeout once occurred and a retry loop was briefly added. Root
+        # cause analysis showed the failure was due to logic (raising before queue publish),
+        # not actual transient unavailability of the metadata endpoint. Adding retries
+        # masked the underlying bug and only injected latency + flakiness surface area.
+        #
+        # Why single attempt is correct for GCP:
+        # 1. GCP metadata service is either immediately reachable or definitively absent.
+        #    (Contrast: Azure IMDS managed identity can 429/throttle legitimately, hence
+        #    bounded exponential retry ONLY on Azure identity acquisition.)
+        # 2. Fast failing keeps cross‑provider race tight and test suite duration low.
+        # 3. Retries make real configuration errors (firewall / network namespace / wrong
+        #    cloud) slower to surface and harder to differentiate from genuine detection.
+        # 4. Every added retry path previously obscured a logic bug rather than fixing a
+        #    platform instability.
+        #
+        # If you believe you need a retry, first capture:
+        #   - exact wall clock timings
+        #   - packet trace or tcpdump showing SYN/SYN-ACK delay OR DNS resolution latency
+        #   - evidence that a second attempt (without any delay you inserted) would have
+        #     succeeded (e.g., manual immediate second curl succeeds while first failed)
+        # and document that evidence in a linked issue. Without that, DO NOT ADD RETRIES.
+        #
+        # This comment is intentionally dry and procedural to discourage casual edits.
+        # Removing it or ignoring its instructions without evidence is a regression.
+        # Single bounded metadata probe (no retry). GCP metadata is either reachable promptly
+        # or not present; retries add latency and can mask a real negative signal.
+        self._log("Trying metadata service (link-local IP, single attempt)")
+
+        # Use link-local IP (169.254.169.254) directly to avoid DNS resolution stalls that
+        # previously caused a thread to hang beyond the orchestrator timeout (leading to an
+        # Empty queue and overall detection timeout). Single attempt with explicit total timeout.
+        loop = asyncio.get_event_loop()
+        start = loop.time()
+        metadata_url = "http://169.254.169.254/computeMetadata/v1/instance/id"
+        try:
+            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=3)) as session:
+                async with session.get(metadata_url, headers={"Metadata-Flavor": "Google"}) as response:  # noqa: S310
+                    if response.status != 200:
+                        raise Exception(f"metadata status {response.status}")
+            elapsed_ms = int((loop.time() - start) * 1000)
+            self._log(f"Detected GCP metadata (elapsed={elapsed_ms}ms)")
+            self._detected = True
+            return
+        except Exception as e:  # noqa: BLE001
+            elapsed_ms = int((loop.time() - start) * 1000)
+            msg = str(e) or type(e).__name__
+            lower = msg.lower()
+            if any(p in lower for p in ("name or service not known", "temporary failure", "not known")):
+                category = "dns"
+            elif any(p in lower for p in ("timed out", "timeout")):
+                category = "timeout"
+            elif any(p in lower for p in ("refused", "connection reset")):
+                category = "connect"
+            else:
+                category = "other"
+            self._log(f"Metadata probe failed (elapsed={elapsed_ms}ms category={category}): {msg}")
             raise Exception(
-                f"Not running on GCP: metadata service unavailable (no GCE_METADATA_HOST env var and cannot reach metadata.google.internal): {error_msg}"  # noqa: E501
+                "Not running on GCP: metadata service unavailable (single attempt to 169.254.169.254 failed): "
+                + f"{msg}"
             )
 
         raise Exception(
             "Not running on GCP: no environment variable, metadata service, or default credentials detected"
         )
+
+    async def fast_detect(self) -> None:
+        """Fast detection: env/file only, no network."""
+        # external_account credential file
+        cred_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+        if cred_path and os.path.isfile(cred_path):
+            try:  # noqa: BLE001
+                content = open(cred_path, "r", encoding="utf-8").read(4096)
+                if '"type"' in content and '"external_account"' in content:
+                    self._log("FastDetect: external_account credentials present")
+                    self._detected = True
+                    return
+            except Exception as e:  # noqa: BLE001
+                self._log(f"FastDetect: credential file read failed: {e}")
+
+        if os.environ.get("GCE_METADATA_HOST"):
+            # Do NOT verify network here; leave that to full detect
+            self._log("FastDetect: GCE_METADATA_HOST present")
+            self._detected = True
+            return
+        raise Exception("FastDetect: no GCP indicators")
 
     async def _verify_metadata_access(self) -> None:
         """Verify we can access identity-related metadata."""

--- a/python/src/s2iam/models.py
+++ b/python/src/s2iam/models.py
@@ -17,7 +17,7 @@ class CloudProviderType(Enum):
 
 
 class JWTType(Enum):
-    """JWT token types."""
+    """JWT types."""
 
     DATABASE_ACCESS = "database"
     API_GATEWAY_ACCESS = "api"

--- a/python/src/s2iam/models.py
+++ b/python/src/s2iam/models.py
@@ -47,9 +47,23 @@ class CloudProviderClient(ABC):
     """Abstract base class for cloud provider clients."""
 
     @abstractmethod
+    async def fast_detect(self) -> None:
+        """Attempt a zero/near-zero latency detection using only local state.
+
+        This MUST NOT perform any network I/O. It should only inspect environment
+        variables and local filesystem paths explicitly referenced by env vars.
+
+        On success, the implementation should set its internal detected flag and
+        return. On failure (no positive indicators) it should raise an exception
+        (type/value unimportant – caller treats any exception as "not detected").
+        """
+        ...
+
+    @abstractmethod
     async def detect(self) -> None:
         """
-        Test if we are executing within this cloud provider.
+        Test if we are executing within this cloud provider. fast_detect must
+        be called first.
 
         Raises:
             Exception: If provider is not detected or unavailable

--- a/python/tests/test_aws_irsa_detection.py
+++ b/python/tests/test_aws_irsa_detection.py
@@ -1,0 +1,59 @@
+import pytest
+
+from s2iam.aws import new_client
+
+
+class DummyLogger:
+    def __init__(self):
+        self.messages = []
+
+    def log(self, msg: str) -> None:  # pragma: no cover - helper
+        self.messages.append(msg)
+
+
+@pytest.mark.asyncio
+async def test_irsa_short_circuit_detection(monkeypatch):
+    # Ensure other detection paths are absent
+    for var in [
+        "AWS_EXECUTION_ENV",
+        "AWS_REGION",
+        "AWS_DEFAULT_REGION",
+        "AWS_LAMBDA_FUNCTION_NAME",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+
+    # Provide IRSA env var using a temp token file instead of cluster path
+    import pathlib
+    import tempfile
+
+    tmp_dir = tempfile.TemporaryDirectory()
+    token_path = pathlib.Path(tmp_dir.name) / "token"
+    token_path.write_text("dummy")
+    monkeypatch.setenv("AWS_WEB_IDENTITY_TOKEN_FILE", str(token_path))
+    monkeypatch.setenv("AWS_ROLE_ARN", "arn:aws:iam::123456789012:role/MyServiceAccountRole")
+
+    logger = DummyLogger()
+    client = new_client(logger)
+
+    # Fast detection should succeed immediately without invoking full detection network paths
+    await client.fast_detect()
+    assert any("IRSA environment" in m for m in logger.messages), logger.messages
+
+
+@pytest.mark.asyncio
+async def test_irsa_negative_without_vars(monkeypatch):
+    monkeypatch.delenv("AWS_WEB_IDENTITY_TOKEN_FILE", raising=False)
+    monkeypatch.delenv("AWS_ROLE_ARN", raising=False)
+    # Remove env shortcuts
+    for var in [
+        "AWS_EXECUTION_ENV",
+        "AWS_REGION",
+        "AWS_DEFAULT_REGION",
+        "AWS_LAMBDA_FUNCTION_NAME",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+
+    client = new_client()
+    # Expect fast detection to fail immediately (no env indicators)
+    with pytest.raises(Exception):  # broad: fast_detect raises generic Exception when no indicators
+        await client.fast_detect()

--- a/python/tests/test_cloud_validation.py
+++ b/python/tests/test_cloud_validation.py
@@ -1,5 +1,6 @@
 """Cloud validation tests that run against real cloud provider services."""
 
+import json
 import os
 import re
 import time
@@ -234,3 +235,79 @@ class TestErrorHandlingValidation:
             ):
                 pytest.fail("Cloud provider detection failed - expected to detect provider in test environment")
             pytest.skip("No cloud provider detected")
+
+
+class TestLocalOnlyFastPathCancelledContext:
+    """Local-only tests for IRSA / workload identity fast detection with cancelled context.
+
+    These mirror the Go cancelled-context fast-path tests but are explicitly skipped when
+    running in configured cloud test environments. They validate that FastDetect logic
+    (env/file only) executes without consulting context cancellation.
+    """
+
+    def _is_cloud_test_env(self) -> bool:
+        return bool(
+            os.environ.get("S2IAM_TEST_CLOUD_PROVIDER")
+            or os.environ.get("S2IAM_TEST_CLOUD_PROVIDER_NO_ROLE")
+            or os.environ.get("S2IAM_TEST_ASSUME_ROLE")
+        )
+
+    @pytest.mark.asyncio
+    async def test_aws_irsa_cancelled_context(self, tmp_path):
+        if self._is_cloud_test_env():
+            pytest.skip("IRSA cancelled-context fast-path test is local-only")
+
+        # Create dummy token file
+        token_file = tmp_path / "irsa-token.txt"
+        token_file.write_text("dummy-token")
+        os.environ["AWS_WEB_IDENTITY_TOKEN_FILE"] = str(token_file)
+        os.environ["AWS_ROLE_ARN"] = "arn:aws:iam::123456789012:role/TestRole"
+
+        from s2iam.aws import new_client as new_aws_client
+
+        aws_client = new_aws_client()
+        await aws_client.fast_detect()
+        assert aws_client.get_type() == s2iam.CloudProviderType.AWS
+
+    @pytest.mark.asyncio
+    async def test_gcp_workload_identity_cancelled_context(self, tmp_path):
+        if self._is_cloud_test_env():
+            pytest.skip("GCP workload identity cancelled-context test is local-only")
+
+        # external_account credentials file
+        creds_file = tmp_path / "gcp-external.json"
+        creds_file.write_text(
+            json.dumps(
+                {
+                    "type": "external_account",
+                    "audience": (
+                        "//iam.googleapis.com/projects/123/locations/global/"
+                        "workloadIdentityPools/pool/providers/provider"
+                    ),
+                }
+            )
+        )
+        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = str(creds_file)
+
+        from s2iam.gcp import new_client as new_gcp_client
+
+        gcp_client = new_gcp_client()
+        await gcp_client.fast_detect()
+        assert gcp_client.get_type() == s2iam.CloudProviderType.GCP
+
+    @pytest.mark.asyncio
+    async def test_azure_workload_identity_cancelled_context(self, tmp_path):
+        if self._is_cloud_test_env():
+            pytest.skip("Azure workload identity cancelled-context test is local-only")
+
+        token_file = tmp_path / "azure-federated-token.txt"
+        token_file.write_text("dummy-azure-token")
+        os.environ["AZURE_FEDERATED_TOKEN_FILE"] = str(token_file)
+        os.environ["AZURE_CLIENT_ID"] = "00000000-0000-0000-0000-000000000000"
+        os.environ["AZURE_TENANT_ID"] = "11111111-1111-1111-1111-111111111111"
+
+        from s2iam.azure import new_client as new_azure_client
+
+        azure_client = new_azure_client()
+        await azure_client.fast_detect()
+        assert azure_client.get_type() == s2iam.CloudProviderType.AZURE

--- a/python/tests/test_fastpath.py
+++ b/python/tests/test_fastpath.py
@@ -14,7 +14,7 @@ import s2iam
 from s2iam import CloudProviderType
 
 from .test_server_utils import GoTestServerManager
-from .testhelp import TEST_DETECT_TIMEOUT, expect_cloud_provider_detected, validate_identity_and_jwt
+from .testhelp import expect_cloud_provider_detected, validate_identity_and_jwt
 
 
 @pytest.mark.asyncio
@@ -23,41 +23,64 @@ class TestFastPathDetection:
 
     async def test_fastpath_detection(self):
         """Test that fast-path detection produces same results as full detection."""
+        # Skip on NO_ROLE hosts since we need working cloud provider detection
         if os.environ.get("S2IAM_TEST_CLOUD_PROVIDER_NO_ROLE"):
             pytest.skip("test requires working cloud role - skipped on no-role hosts")
 
-        normal_provider = await expect_cloud_provider_detected(timeout=TEST_DETECT_TIMEOUT)
+        # Skip if not in a cloud environment - this should work on both role and no-role hosts
+        normal_provider = await expect_cloud_provider_detected(timeout=10.0)
         provider_type = normal_provider.get_type()
+
         print(f"Detected provider: {provider_type.value}")
 
-        # Decide env vars enabling fast-path
+        # Build variant list (label, env_dict) to exercise multiple AWS fast-paths (env + IRSA)
+        variants: list[tuple[str, dict[str, str]]] = []
+
         if provider_type == CloudProviderType.AWS:
-            env_vars_to_set = {"AWS_EXECUTION_ENV": "AWS_EC2"}
+            # Classic AWS env fast-path
+            classic_env = {"AWS_EXECUTION_ENV": "AWS_EC2"}
             region = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
             if region:
-                env_vars_to_set["AWS_REGION"] = region
+                classic_env["AWS_REGION"] = region
+            variants.append(("aws-env", classic_env))
+
+            # IRSA fast-path variant: set only AWS_ROLE_ARN (detection accepts either env var).
+            irsa_env = {"AWS_ROLE_ARN": "arn:aws:iam::123456789012:role/S2IAMTestRole"}
+            if region:
+                irsa_env["AWS_REGION"] = region
+            variants.append(("aws-irsa", irsa_env))
+
         elif provider_type == CloudProviderType.GCP:
-            env_vars_to_set = {"GCE_METADATA_HOST": "metadata.google.internal"}
+            variants.append(("gcp-env", {"GCE_METADATA_HOST": "metadata.google.internal"}))
         elif provider_type == CloudProviderType.AZURE:
-            env_vars_to_set = {"AZURE_ENV": "AzureCloud"}
+            variants.append(("azure-env", {"AZURE_ENV": "AzureCloud"}))
         else:
             pytest.fail(f"Unknown provider type: {provider_type}")
 
-        # Fast-path detection under env vars
-        with patch.dict(os.environ, env_vars_to_set):
-            for k, v in env_vars_to_set.items():
-                print(f"Set {k}={v} for fast-path detection")
-            fastpath_provider = await s2iam.detect_provider(timeout=TEST_DETECT_TIMEOUT / 3)
-            assert (
-                normal_provider.get_type() == fastpath_provider.get_type()
-            ), "Fast-path detection should give same provider type as normal detection"
-            print(f"Fast-path detection test passed for {provider_type.value}")
-            print(f"Normal detection provider: {normal_provider.get_type().value}")
-            print(f"Fast-path detection provider: {fastpath_provider.get_type().value}")
-            if os.environ.get("S2IAM_TEST_CLOUD_PROVIDER_NO_ROLE"):
-                print("Skipping header testing on NO_ROLE host")
-                return
-            await self._test_equivalent_functionality(normal_provider, fastpath_provider)
+        for label, env_vars in variants:
+            print(f"\n=== Fast-path variant: {label} ===")
+            # Remove internal temp dir handle key before patching environment
+            env_vars = dict(env_vars)  # shallow copy
+            _tmp_dir_handle = env_vars.pop("_TMP_DIR_HANDLE", None)  # legacy key if present
+            with patch.dict(os.environ, env_vars):
+                for k, v in env_vars.items():
+                    print(f"Set {k}={v} for variant {label}")
+
+                fastpath_provider = await s2iam.detect_provider(timeout=5.0)
+                assert normal_provider.get_type() == fastpath_provider.get_type(), f"Variant {label}: provider mismatch"
+                print(
+                    "Variant {label} passed: normal={n} fast={f}".format(
+                        label=label,
+                        n=normal_provider.get_type().value,
+                        f=fastpath_provider.get_type().value,
+                    )
+                )
+
+                if os.environ.get("S2IAM_TEST_CLOUD_PROVIDER_NO_ROLE"):
+                    print("Skipping header/JWT validation on NO_ROLE host")
+                    continue
+
+                await self._test_equivalent_functionality(normal_provider, fastpath_provider)
 
     async def _test_equivalent_functionality(self, normal_provider, fastpath_provider):
         """Test that both providers produce equivalent results."""

--- a/python/tests/test_server_utils.py
+++ b/python/tests/test_server_utils.py
@@ -2,10 +2,10 @@
 Shared test utilities for managing the Go test server.
 """
 
+import json
 import logging
 import os
 import subprocess
-import json
 import time
 from typing import Optional
 

--- a/python/tests/testhelp.py
+++ b/python/tests/testhelp.py
@@ -98,16 +98,16 @@ async def validate_identity_and_jwt(
     headers, identity = await provider.get_identity_headers(additional_params)
 
     # Request JWT via convenience function (database JWT selected for richer validation)
-    jwt_token = await s2iam.get_jwt_database(
+    token = await s2iam.get_jwt_database(
         workspace_group_id=workspace_group_id,
         server_url=server_url,
         provider=provider,
         additional_params=additional_params,
     )
-    assert jwt_token and jwt_token.count(".") == 2, "JWT structure invalid"
+    assert token and token.count(".") == 2, "JWT structure invalid"
 
     # Decode payload (test server signature not verified here)
-    parts = jwt_token.split(".")
+    parts = token.split(".")
     payload_b64 = parts[1] + "=" * (4 - len(parts[1]) % 4)
     try:
         claims: Dict[str, Any] = json.loads(base64.urlsafe_b64decode(payload_b64))


### PR DESCRIPTION
Splits detection into a fast detect and regular detect phase. Fast detect is synchronous, fast, and called sequentially for all CSPs.

IRSA/Workload Identity is detected during fast detect.

Azure, and only Azure gets retries on API 429 failures. The other CSPs don't return 429.

GCP API calls now use the IP address, avoiding DNS issues.

Improvements to errors returned to make debugging easier.


