### PR TITLE
Require HTTPS auth server URLs in Go client

### DIFF
--- a/go/cmd/integration_test.go
+++ b/go/cmd/integration_test.go
@@ -152,6 +152,7 @@ func TestIntegration_ServerAndClient(t *testing.T) {
 	// Run client against test server - should succeed with real cloud provider
 	clientCmd := exec.Command(clientBinary,
 		"--server-url", endpoints["auth"],
+		"--allow-http",
 		"--jwt-type", "api",
 		"--env-name", "TOKEN",
 		"--env-status", "STATUS")

--- a/go/cmd/s2iam/main.go
+++ b/go/cmd/s2iam/main.go
@@ -28,6 +28,7 @@ type Config struct {
 	AssumeRole string
 	Timeout    time.Duration
 	ServerURL  string
+	AllowHTTP  bool
 
 	// Output options
 	EnvName   string
@@ -80,6 +81,7 @@ func parseFlags(flagSet *flag.FlagSet, args []string) (Config, error) {
 	flagSet.StringVar(&config.AssumeRole, "assume-role", "", "Role to assume (ARN for AWS, service account for GCP, managed identity for Azure)")
 	flagSet.DurationVar(&config.Timeout, "timeout", 10*time.Second, "Timeout for operations")
 	flagSet.StringVar(&config.ServerURL, "server-url", "", "Authentication server URL (uses default if not specified)")
+	flagSet.BoolVar(&config.AllowHTTP, "allow-http", false, "Allow an http:// authentication server URL for local testing")
 	flagSet.StringVar(&config.EnvName, "env-name", "", "Environment variable name for JWT output")
 	flagSet.StringVar(&config.EnvStatus, "env-status", "", "Environment variable name for status output")
 	flagSet.BoolVar(&config.Verbose, "verbose", false, "Enable verbose logging")
@@ -186,6 +188,9 @@ func run(config Config) error {
 
 	if config.ServerURL != "" {
 		opts = append(opts, s2iam.WithServerURL(config.ServerURL))
+	}
+	if config.AllowHTTP {
+		opts = append(opts, s2iam.WithAllowHTTP())
 	}
 
 	// Get JWT

--- a/go/cmd/s2iam/main_test.go
+++ b/go/cmd/s2iam/main_test.go
@@ -128,6 +128,7 @@ func TestRun_Success(t *testing.T) {
 		JWTType:          "database",
 		WorkspaceGroupID: "test-workspace",
 		ServerURL:        server.URL + "/auth/iam/:jwtType",
+		AllowHTTP:        true,
 		Timeout:          10 * time.Second,
 	}
 
@@ -201,6 +202,7 @@ func TestRun_EnvironmentOutput(t *testing.T) {
 		JWTType:          "database",
 		WorkspaceGroupID: "test-workspace",
 		ServerURL:        server.URL + "/auth/iam/:jwtType",
+		AllowHTTP:        true,
 		EnvName:          "TOKEN",
 		EnvStatus:        "STATUS",
 		Timeout:          10 * time.Second,
@@ -253,6 +255,7 @@ func TestRealMain(t *testing.T) {
 				"cmd",
 				"--workspace-group-id", "test-workspace",
 				"--server-url", "http://mock-server/auth/iam/:jwtType", // Will be replaced if test runs
+				"--allow-http",
 			},
 			exitCode: 0,
 			wantErr:  false,

--- a/go/s2iam/jwt.go
+++ b/go/s2iam/jwt.go
@@ -39,6 +39,7 @@ type jwtOptions struct {
 	JWTType              JWTType
 	WorkspaceGroupID     string
 	ServerURL            string
+	AllowHTTP            bool
 	Provider             models.CloudProviderClient
 	AdditionalParams     map[string]string
 	AssumeRoleIdentifier string
@@ -48,6 +49,14 @@ type jwtOptions struct {
 func WithServerURL(serverURL string) JWTOption {
 	return jwtOption(func(o *jwtOptions) {
 		o.ServerURL = serverURL
+	})
+}
+
+// WithAllowHTTP permits http:// authentication server URLs for local testing.
+// HTTPS is required by default.
+func WithAllowHTTP() JWTOption {
+	return jwtOption(func(o *jwtOptions) {
+		o.AllowHTTP = true
 	})
 }
 
@@ -128,6 +137,13 @@ func getJWT(ctx context.Context, defaultOpts jwtOptions, opts []JWTOption) (stri
 	uri, err := url.Parse(targetURL)
 	if err != nil {
 		return "", errors.Errorf("invalid server URL: %w", err)
+	}
+	if uri.Scheme != "https" {
+		if uri.Scheme == "http" && jwtOpts.AllowHTTP {
+			// Explicitly allowed for local test servers.
+		} else {
+			return "", errors.Errorf("server URL must use https (got %q); use WithAllowHTTP for local testing", uri.Scheme)
+		}
 	}
 
 	// Add query parameters

--- a/go/s2iam/s2iam_test.go
+++ b/go/s2iam/s2iam_test.go
@@ -212,13 +212,15 @@ func testHappyPath(t *testing.T, client s2iam.CloudProviderClient) {
 
 		token, err = s2iam.GetDatabaseJWT(ctx, "test-workspace",
 			s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"),
+			s2iam.WithAllowHTTP(),
 			s2iam.WithGCPAudience("https://authsvc.singlestore.com"))
 	} else {
 		_, clientIdentity, err = client.GetIdentityHeaders(ctx, nil)
 		require.NoError(t, err, "Failed to get client-side identity")
 
 		token, err = s2iam.GetDatabaseJWT(ctx, "test-workspace",
-			s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"))
+			s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"),
+			s2iam.WithAllowHTTP())
 	}
 
 	require.NoError(t, err)
@@ -300,10 +302,12 @@ func TestGetAPIJWT(t *testing.T) {
 		// On real GCP, explicitly use the default audience to ensure compatibility
 		token, err = s2iam.GetAPIJWT(ctx,
 			s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"),
+			s2iam.WithAllowHTTP(),
 			s2iam.WithGCPAudience("https://authsvc.singlestore.com"))
 	} else {
 		token, err = s2iam.GetAPIJWT(ctx,
-			s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"))
+			s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"),
+			s2iam.WithAllowHTTP())
 	}
 
 	require.NoError(t, err)
@@ -334,7 +338,8 @@ func TestGetDatabaseJWT_EmptyJWT(t *testing.T) {
 
 	ctx := context.Background()
 	_, err := s2iam.GetDatabaseJWT(ctx, "test-workspace",
-		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"))
+		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"),
+		s2iam.WithAllowHTTP())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "received empty JWT")
@@ -350,7 +355,8 @@ func TestGetDatabaseJWT_InvalidJSON(t *testing.T) {
 
 	ctx := context.Background()
 	_, err := s2iam.GetDatabaseJWT(ctx, "test-workspace",
-		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"))
+		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"),
+		s2iam.WithAllowHTTP())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot parse response")
@@ -366,7 +372,8 @@ func TestGetDatabaseJWT_ServerError(t *testing.T) {
 
 	ctx := context.Background()
 	_, err := s2iam.GetDatabaseJWT(ctx, "test-workspace",
-		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"))
+		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"),
+		s2iam.WithAllowHTTP())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "authentication server returned status 500")
@@ -382,7 +389,8 @@ func TestGetDatabaseJWT_VerificationFailure(t *testing.T) {
 
 	ctx := context.Background()
 	_, err := s2iam.GetDatabaseJWT(ctx, "test-workspace",
-		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"))
+		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"),
+		s2iam.WithAllowHTTP())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "authentication server returned status 401")
@@ -410,6 +418,7 @@ func TestGetDatabaseJWT_GCPAudience(t *testing.T) {
 		ctx := context.Background()
 		token, err := s2iam.GetDatabaseJWT(ctx, "test-workspace",
 			s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"),
+			s2iam.WithAllowHTTP(),
 			s2iam.WithGCPAudience("https://authsvc.singlestore.com"))
 		require.NoError(t, err)
 		require.NotEmpty(t, token)
@@ -424,6 +433,7 @@ func TestGetDatabaseJWT_GCPAudience(t *testing.T) {
 	ctx := context.Background()
 	token, err := s2iam.GetDatabaseJWT(ctx, "test-workspace",
 		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"),
+		s2iam.WithAllowHTTP(),
 		s2iam.WithGCPAudience("https://test.example.com"))
 
 	require.NoError(t, err)
@@ -447,7 +457,8 @@ func TestGetDatabaseJWT_AssumeRole_Valid(t *testing.T) {
 
 	ctx := context.Background()
 	originalJWT, err := s2iam.GetDatabaseJWT(ctx, "test-workspace",
-		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"))
+		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"),
+		s2iam.WithAllowHTTP())
 	require.NoError(t, err)
 	originalClaims := validateJWT(t, originalJWT)
 	originalIdentifier := originalClaims["sub"].(string)
@@ -459,6 +470,7 @@ func TestGetDatabaseJWT_AssumeRole_Valid(t *testing.T) {
 	// Now test with role assumption
 	assumedJWT, err := s2iam.GetDatabaseJWT(ctx, "test-workspace",
 		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"),
+		s2iam.WithAllowHTTP(),
 		s2iam.WithAssumeRole(roleIdentifier))
 
 	// Since S2IAM_TEST_ASSUME_ROLE is set, role assumption MUST succeed
@@ -527,6 +539,7 @@ func TestGetDatabaseJWT_AssumeRole_InvalidRole(t *testing.T) {
 
 	_, err := s2iam.GetDatabaseJWT(ctx, "test-workspace",
 		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"),
+		s2iam.WithAllowHTTP(),
 		s2iam.WithAssumeRole(invalidRole))
 
 	// This should fail since the role doesn't exist (or AssumeRole isn't supported)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Require Go JWT auth server URLs to use HTTPS by default
- Add `WithAllowHTTP()` and CLI `--allow-http` for local/mock test servers
- Update Go tests and integration command paths that intentionally use HTTP

## Testing
- `go test ./s2iam ./cmd/s2iam`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1b0e1d3-3387-4313-b30c-851785d85b29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1b0e1d3-3387-4313-b30c-851785d85b29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

