### PR TITLE
Require HTTPS auth server URLs in Python client

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -117,7 +117,8 @@ Get a JWT from SingleStore's authentication service.
 **Parameters:**
 - `jwt_type` (JWTType): Type of JWT to request
 - `workspace_group_id` (str): Workspace group ID
-- `server_url` (str): Authentication server URL
+- `server_url` (str): Authentication server URL. Custom URLs must use HTTPS by default.
+- `allow_http` (bool): Allow an HTTP `server_url` for local testing only.
 - `**kwargs`: Additional provider-specific parameters
 
 **Returns:** `str` (JWT)

--- a/python/src/s2iam/jwt.py
+++ b/python/src/s2iam/jwt.py
@@ -3,6 +3,7 @@ JWT functionality for SingleStore authentication.
 """
 
 from typing import Any, Optional
+from urllib.parse import urlparse
 
 import aiohttp
 
@@ -15,6 +16,15 @@ from .models import (
 DEFAULT_SERVER_URL = "https://authsvc.singlestore.com/auth/iam/{jwt_type}"
 
 
+def _validate_server_url(server_url: str, allow_http: bool) -> None:
+    scheme = urlparse(server_url).scheme
+    if scheme == "https":
+        return
+    if scheme == "http" and allow_http:
+        return
+    raise ValueError(f"server_url must use https (got {scheme!r}); pass allow_http=True for local testing")
+
+
 async def get_jwt(
     jwt_type: JWTType,
     workspace_group_id: Optional[str] = None,
@@ -23,6 +33,7 @@ async def get_jwt(
     additional_params: Optional[dict[str, str]] = None,
     assume_role_identifier: Optional[str] = None,
     timeout: float = 10.0,
+    allow_http: bool = False,
     logger: Optional[Logger] = None,
     **kwargs: Any,
 ) -> str:
@@ -38,6 +49,7 @@ async def get_jwt(
             Only used for database JWTs. When None, the JWT may have broader access.
         timeout (float): Timeout in seconds for the request
         server_url (Optional[str]): Override the default server URL
+        allow_http (bool): Allow an http:// server URL for local testing
         logger (Optional[Logger]): Logger instance for debug output
 
     Returns:
@@ -70,6 +82,7 @@ async def get_jwt(
             server_url = env_server_url
         else:
             server_url = DEFAULT_SERVER_URL.format(jwt_type=jwt_type.value)
+    _validate_server_url(server_url, allow_http)
 
     # Prepare request body
     request_data = {
@@ -126,6 +139,7 @@ async def get_jwt_database(
     additional_params: Optional[dict[str, str]] = None,
     assume_role_identifier: Optional[str] = None,
     timeout: float = 10.0,
+    allow_http: bool = False,
     logger: Optional[Logger] = None,
     **kwargs: Any,
 ) -> str:
@@ -139,6 +153,7 @@ async def get_jwt_database(
         additional_params: Additional provider-specific parameters
         assume_role_identifier: Role to assume before getting JWT
         timeout: Request timeout in seconds
+        allow_http: Allow an http:// server URL for local testing
         logger: Optional logger instance
         **kwargs: Additional options
 
@@ -153,6 +168,7 @@ async def get_jwt_database(
         additional_params=additional_params,
         assume_role_identifier=assume_role_identifier,
         timeout=timeout,
+        allow_http=allow_http,
         logger=logger,
         **kwargs,
     )
@@ -165,6 +181,7 @@ async def get_jwt_api(
     additional_params: Optional[dict[str, str]] = None,
     assume_role_identifier: Optional[str] = None,
     timeout: float = 10.0,
+    allow_http: bool = False,
     logger: Optional[Logger] = None,
     **kwargs: Any,
 ) -> str:
@@ -177,6 +194,7 @@ async def get_jwt_api(
         additional_params: Additional provider-specific parameters
         assume_role_identifier: Role to assume before getting JWT
         timeout: Request timeout in seconds
+        allow_http: Allow an http:// server URL for local testing
         logger: Optional logger instance
         **kwargs: Additional options
 
@@ -191,6 +209,7 @@ async def get_jwt_api(
         additional_params=additional_params,
         assume_role_identifier=assume_role_identifier,
         timeout=timeout,
+        allow_http=allow_http,
         logger=logger,
         **kwargs,
     )

--- a/python/tests/test_cloud_validation.py
+++ b/python/tests/test_cloud_validation.py
@@ -123,6 +123,7 @@ class TestProviderSpecificIntegration:
                 server_url=f"{test_server.server_url}/auth/iam/database",
                 provider=provider,
                 workspace_group_id="test-workspace",
+                allow_http=True,
             )
 
             assert jwt is not None
@@ -167,6 +168,7 @@ class TestProviderSpecificIntegration:
                 server_url=f"{test_server.server_url}/auth/iam/database",
                 provider=provider,
                 workspace_group_id="test-workspace",
+                allow_http=True,
             )
 
             assert jwt is not None

--- a/python/tests/test_integration.py
+++ b/python/tests/test_integration.py
@@ -91,6 +91,7 @@ class TestJWTIntegration:
                 server_url=f"{test_server.server_url}/auth/iam/database",
                 provider=provider,
                 workspace_group_id="test-workspace",
+                allow_http=True,
             )
 
             assert jwt is not None
@@ -123,6 +124,7 @@ class TestJWTIntegration:
                     server_url=f"{test_server.server_url}/auth/iam/{jwt_type.value}",
                     provider=provider,
                     workspace_group_id="test-workspace",
+                    allow_http=True,
                 )
 
                 assert jwt is not None

--- a/python/tests/test_jwt.py
+++ b/python/tests/test_jwt.py
@@ -1,0 +1,43 @@
+"""Tests for JWT request behavior."""
+
+import pytest
+
+from s2iam import CloudIdentity, CloudProviderType, JWTType, get_jwt
+from s2iam.jwt import _validate_server_url
+from s2iam.models import CloudProviderClient
+
+
+class FakeProvider(CloudProviderClient):
+    async def fast_detect(self) -> None:
+        return None
+
+    async def detect(self) -> None:
+        return None
+
+    def get_type(self) -> CloudProviderType:
+        return CloudProviderType.AWS
+
+    def assume_role(self, role_identifier: str) -> "CloudProviderClient":
+        return self
+
+    async def get_identity_headers(self, additional_params=None) -> tuple[dict[str, str], CloudIdentity]:
+        return {}, CloudIdentity(
+            provider=CloudProviderType.AWS,
+            identifier="arn:aws:iam::123456789012:role/TestRole",
+            account_id="123456789012",
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_jwt_rejects_http_server_url_by_default():
+    with pytest.raises(ValueError, match="server_url must use https"):
+        await get_jwt(
+            jwt_type=JWTType.DATABASE_ACCESS,
+            workspace_group_id="test-workspace",
+            server_url="http://localhost/auth/iam/database",
+            provider=FakeProvider(),
+        )
+
+
+def test_validate_server_url_allows_http_when_explicitly_enabled():
+    _validate_server_url("http://localhost/auth/iam/database", allow_http=True)

--- a/python/tests/testhelp.py
+++ b/python/tests/testhelp.py
@@ -104,6 +104,7 @@ async def validate_identity_and_jwt(
         server_url=server_url,
         provider=provider,
         additional_params=additional_params,
+        allow_http=True,
     )
     assert token and token.count(".") == 2, "JWT structure invalid"
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Require Python JWT auth server URLs to use HTTPS by default
- Add `allow_http=True` opt-in for local/mock test servers
- Update Python integration helpers/tests that intentionally use HTTP and document the option

## Testing
- Not run yet (pre-test PR checkpoint).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1b0e1d3-3387-4313-b30c-851785d85b29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1b0e1d3-3387-4313-b30c-851785d85b29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

