### PR TITLE
Require HTTPS for authentication server URLs by default

### DIFF
--- a/.github/workflows/cloud_provider.yml
+++ b/.github/workflows/cloud_provider.yml
@@ -114,7 +114,7 @@ jobs:
         echo "=== Python Coverage (first lines) ==="; head -10 python-coverage.xml || true
 
     - name: Upload Go coverage to Codecov
-      uses: codecov/codecov-action@v5.5.1
+      uses: codecov/codecov-action@v5.5.5
       with:
         files: ./go-coverage.out
         flags: go,${{ matrix.name }}
@@ -124,7 +124,7 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload Python coverage to Codecov
-      uses: codecov/codecov-action@v5.5.1
+      uses: codecov/codecov-action@v5.5.5
       with:
         files: ./python-coverage.xml
         flags: python,${{ matrix.name }}
@@ -134,7 +134,7 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Upload Java coverage to Codecov
-      uses: codecov/codecov-action@v5.5.1
+      uses: codecov/codecov-action@v5.5.5
       with:
         files: ./java-coverage.xml
         flags: java,${{ matrix.name }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -33,7 +33,7 @@ jobs:
           head -2 go/coverage.out
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5.5.1
+        uses: codecov/codecov-action@v5.5.5
         with:
           fail_ci_if_error: true
           name: base-coverage

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -39,7 +39,7 @@ jobs:
           fi
 
       - name: Upload Java coverage to Codecov
-        uses: codecov/codecov-action@v5.5.1
+        uses: codecov/codecov-action@v5.5.5
         with:
           files: java/target/site/jacoco/jacoco.xml
           flags: java

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -47,7 +47,7 @@ jobs:
     
     - name: Upload coverage to Codecov
       if: matrix.python-version == '3.11'
-      uses: codecov/codecov-action@v5.5.1
+      uses: codecov/codecov-action@v5.5.5
       with:
         files: ./python/coverage.xml
         flags: python

--- a/go/cmd/integration_test.go
+++ b/go/cmd/integration_test.go
@@ -152,6 +152,7 @@ func TestIntegration_ServerAndClient(t *testing.T) {
 	// Run client against test server - should succeed with real cloud provider
 	clientCmd := exec.Command(clientBinary,
 		"--server-url", endpoints["auth"],
+		"--allow-http",
 		"--jwt-type", "api",
 		"--env-name", "TOKEN",
 		"--env-status", "STATUS")

--- a/go/cmd/s2iam/main.go
+++ b/go/cmd/s2iam/main.go
@@ -28,6 +28,7 @@ type Config struct {
 	AssumeRole string
 	Timeout    time.Duration
 	ServerURL  string
+	AllowHTTP  bool
 
 	// Output options
 	EnvName   string
@@ -80,6 +81,7 @@ func parseFlags(flagSet *flag.FlagSet, args []string) (Config, error) {
 	flagSet.StringVar(&config.AssumeRole, "assume-role", "", "Role to assume (ARN for AWS, service account for GCP, managed identity for Azure)")
 	flagSet.DurationVar(&config.Timeout, "timeout", 10*time.Second, "Timeout for operations")
 	flagSet.StringVar(&config.ServerURL, "server-url", "", "Authentication server URL (uses default if not specified)")
+	flagSet.BoolVar(&config.AllowHTTP, "allow-http", false, "Allow http:// authentication server URLs (for testing only)")
 	flagSet.StringVar(&config.EnvName, "env-name", "", "Environment variable name for JWT output")
 	flagSet.StringVar(&config.EnvStatus, "env-status", "", "Environment variable name for status output")
 	flagSet.BoolVar(&config.Verbose, "verbose", false, "Enable verbose logging")
@@ -186,6 +188,9 @@ func run(config Config) error {
 
 	if config.ServerURL != "" {
 		opts = append(opts, s2iam.WithServerURL(config.ServerURL))
+	}
+	if config.AllowHTTP {
+		opts = append(opts, s2iam.WithAllowHTTP())
 	}
 
 	// Get JWT

--- a/go/cmd/s2iam/main_test.go
+++ b/go/cmd/s2iam/main_test.go
@@ -128,6 +128,7 @@ func TestRun_Success(t *testing.T) {
 		JWTType:          "database",
 		WorkspaceGroupID: "test-workspace",
 		ServerURL:        server.URL + "/auth/iam/:jwtType",
+		AllowHTTP:        true,
 		Timeout:          10 * time.Second,
 	}
 

--- a/go/cmd/s2iam/main_test.go
+++ b/go/cmd/s2iam/main_test.go
@@ -201,6 +201,7 @@ func TestRun_EnvironmentOutput(t *testing.T) {
 		JWTType:          "database",
 		WorkspaceGroupID: "test-workspace",
 		ServerURL:        server.URL + "/auth/iam/:jwtType",
+		AllowHTTP:        true,
 		EnvName:          "TOKEN",
 		EnvStatus:        "STATUS",
 		Timeout:          10 * time.Second,
@@ -253,6 +254,7 @@ func TestRealMain(t *testing.T) {
 				"cmd",
 				"--workspace-group-id", "test-workspace",
 				"--server-url", "http://mock-server/auth/iam/:jwtType", // Will be replaced if test runs
+				"--allow-http",
 			},
 			exitCode: 0,
 			wantErr:  false,

--- a/go/cmd/s2iam/main_test.go
+++ b/go/cmd/s2iam/main_test.go
@@ -261,6 +261,17 @@ func TestRealMain(t *testing.T) {
 			wantErr:  false,
 			wantOut:  "test-jwt",
 		},
+		{
+			name: "rejects http server url without allow-http",
+			args: []string{
+				"cmd",
+				"--workspace-group-id", "test-workspace",
+				"--server-url", "http://mock-server/auth/iam/:jwtType", // Will be replaced if test runs
+			},
+			exitCode: 1,
+			wantErr:  true,
+			errMsg:   "authentication server URL must use HTTPS",
+		},
 	}
 
 	validationTests := []struct {
@@ -339,7 +350,13 @@ func TestRealMain(t *testing.T) {
 
 	// Update server URL in cloud tests
 	for i := range cloudTests {
-		cloudTests[i].args[len(cloudTests[i].args)-1] = server.URL + "/auth/iam/:jwtType"
+		args := cloudTests[i].args
+		for j := 0; j < len(args)-1; j++ {
+			if args[j] == "--server-url" {
+				args[j+1] = server.URL + "/auth/iam/:jwtType"
+				break
+			}
+		}
 	}
 
 	// Run cloud-dependent tests
@@ -370,6 +387,14 @@ func TestRealMain(t *testing.T) {
 			var buf bytes.Buffer
 			_, _ = buf.ReadFrom(r)
 			output := buf.String()
+
+			if tt.wantErr {
+				assert.Error(t, err, "Expected an error for test case: %s", tt.name)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+				return
+			}
 
 			assert.NoError(t, err, "Unexpected error for test case: %s: %v", tt.name, err)
 			assert.Contains(t, output, tt.wantOut)

--- a/go/go.mod
+++ b/go/go.mod
@@ -39,7 +39,6 @@ require (
 	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/singlestore-labs/codegate v0.1.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/go/go.mod
+++ b/go/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/memsql/errors v0.1.0
 	github.com/muir/gwrap v0.4.0
-	github.com/stretchr/testify v1.10.0
+	github.com/stretchr/testify v1.11.1
 	google.golang.org/api v0.246.0
 )
 
@@ -39,6 +39,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/singlestore-labs/codegate v0.1.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel v1.36.0 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -69,8 +69,12 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
+github.com/singlestore-labs/codegate v0.1.0 h1:8ILvtkzKUe/PpdE46rn3WNzLKSPpYpXAz4XWSGikmCQ=
+github.com/singlestore-labs/codegate v0.1.0/go.mod h1:tWRAsZch276Z1hD3Xg1fXtunldcI6ROkcDRhz/8PB9I=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.61.0 h1:q4XOmH/0opmeuJtPsbFNivyl7bCt7yRBbeEm2sC/XtQ=

--- a/go/go.sum
+++ b/go/go.sum
@@ -69,10 +69,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
-github.com/singlestore-labs/codegate v0.1.0 h1:8ILvtkzKUe/PpdE46rn3WNzLKSPpYpXAz4XWSGikmCQ=
-github.com/singlestore-labs/codegate v0.1.0/go.mod h1:tWRAsZch276Z1hD3Xg1fXtunldcI6ROkcDRhz/8PB9I=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=

--- a/go/s2iam/https.go
+++ b/go/s2iam/https.go
@@ -4,19 +4,12 @@ import (
 	"net/url"
 
 	"github.com/memsql/errors"
-	"github.com/singlestore-labs/codegate"
 )
-
-// TODO: INFOSEC-3101 remove this code gate once HTTPS enforcement is stable at production
-var gateS2IAMRequireHTTPS = codegate.New("S2IAMRequireHTTPS")
 
 func validateAuthServerURL(rawURL string, allowHTTP bool) (*url.URL, error) {
 	uri, err := url.Parse(rawURL)
 	if err != nil {
 		return nil, errors.Errorf("invalid server URL: %w", err)
-	}
-	if !gateS2IAMRequireHTTPS.Enabled() {
-		return uri, nil
 	}
 	switch uri.Scheme {
 	case "https":

--- a/go/s2iam/https.go
+++ b/go/s2iam/https.go
@@ -18,7 +18,7 @@ func validateAuthServerURL(rawURL string, allowHTTP bool) (*url.URL, error) {
 		if allowHTTP {
 			return uri, nil
 		}
-		return nil, errors.New("authentication server URL must use HTTPS; use WithAllowHTTP for testing")
+		return nil, errors.New("authentication server URL must use HTTPS; use WithAllowHTTP() for testing")
 	default:
 		return nil, errors.Errorf("authentication server URL must use HTTPS (got scheme %q)", uri.Scheme)
 	}

--- a/go/s2iam/https.go
+++ b/go/s2iam/https.go
@@ -4,12 +4,19 @@ import (
 	"net/url"
 
 	"github.com/memsql/errors"
+	"github.com/singlestore-labs/codegate"
 )
+
+// TODO: INFOSEC-3101 remove this code gate once HTTPS enforcement is stable at production
+var gateS2IAMRequireHTTPS = codegate.New("S2IAMRequireHTTPS")
 
 func validateAuthServerURL(rawURL string, allowHTTP bool) (*url.URL, error) {
 	uri, err := url.Parse(rawURL)
 	if err != nil {
 		return nil, errors.Errorf("invalid server URL: %w", err)
+	}
+	if !gateS2IAMRequireHTTPS.Enabled() {
+		return uri, nil
 	}
 	switch uri.Scheme {
 	case "https":

--- a/go/s2iam/https.go
+++ b/go/s2iam/https.go
@@ -1,0 +1,25 @@
+package s2iam
+
+import (
+	"net/url"
+
+	"github.com/memsql/errors"
+)
+
+func validateAuthServerURL(rawURL string, allowHTTP bool) (*url.URL, error) {
+	uri, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, errors.Errorf("invalid server URL: %w", err)
+	}
+	switch uri.Scheme {
+	case "https":
+		return uri, nil
+	case "http":
+		if allowHTTP {
+			return uri, nil
+		}
+		return nil, errors.New("authentication server URL must use HTTPS; use WithAllowHTTP for testing")
+	default:
+		return nil, errors.Errorf("authentication server URL must use HTTPS (got scheme %q)", uri.Scheme)
+	}
+}

--- a/go/s2iam/https_test.go
+++ b/go/s2iam/https_test.go
@@ -1,0 +1,60 @@
+package s2iam
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateAuthServerURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		rawURL    string
+		allowHTTP bool
+		wantErr   string
+	}{
+		{
+			name:   "https allowed by default",
+			rawURL: "https://authsvc.singlestore.com/auth/iam/database",
+		},
+		{
+			name:      "http allowed when opted in",
+			rawURL:    "http://localhost:8080/auth/iam/database",
+			allowHTTP: true,
+		},
+		{
+			name:    "http rejected by default",
+			rawURL:  "http://localhost:8080/auth/iam/database",
+			wantErr: "authentication server URL must use HTTPS",
+		},
+		{
+			name:    "unsupported scheme rejected",
+			rawURL:  "ftp://example.com/auth/iam/database",
+			wantErr: "authentication server URL must use HTTPS",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := validateAuthServerURL(tt.rawURL, tt.allowHTTP)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestGetAPIJWT_RejectsHTTPWithoutAllowHTTP(t *testing.T) {
+	t.Parallel()
+
+	_, err := GetAPIJWT(t.Context(), WithServerURL("http://localhost:8080/auth/iam/:jwtType"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authentication server URL must use HTTPS")
+}

--- a/go/s2iam/https_test.go
+++ b/go/s2iam/https_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/singlestore-labs/singlestore-auth-iam/go/s2iam/models"
@@ -27,8 +29,85 @@ func (httpsTestStubProvider) GetIdentityHeaders(context.Context, map[string]stri
 	}, nil
 }
 
+const gateDisabledTestEnv = "S2IAM_REQUIRE_HTTPS_GATE_DISABLED_TEST"
+
+func runWithGateDisabled(t *testing.T, testName string) {
+	t.Helper()
+	cmd := exec.Command(os.Args[0], "-test.run=^"+testName+"$", "-test.count=1", "-test.parallel=1")
+	cmd.Env = append(os.Environ(), "DISABLE_CODE_S2IAMRequireHTTPS=1", gateDisabledTestEnv+"=1")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "subprocess output:\n%s", out)
+}
+
+func TestValidateAuthServerURL(t *testing.T) {
+	t.Parallel()
+	require.True(t, gateS2IAMRequireHTTPS.Enabled())
+
+	tests := []struct {
+		name      string
+		rawURL    string
+		allowHTTP bool
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:      "allows https",
+			rawURL:    "https://example.com/auth/iam/api",
+			allowHTTP: false,
+		},
+		{
+			name:      "rejects http without allowHTTP",
+			rawURL:    "http://example.com/auth/iam/api",
+			allowHTTP: false,
+			wantErr:   true,
+			errSubstr: "authentication server URL must use HTTPS",
+		},
+		{
+			name:      "allows http with allowHTTP",
+			rawURL:    "http://example.com/auth/iam/api",
+			allowHTTP: true,
+		},
+		{
+			name:      "rejects non-http schemes",
+			rawURL:    "ftp://example.com/auth/iam/api",
+			allowHTTP: false,
+			wantErr:   true,
+			errSubstr: "authentication server URL must use HTTPS",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := validateAuthServerURL(tt.rawURL, tt.allowHTTP)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateAuthServerURL_GateDisabled(t *testing.T) {
+	if os.Getenv(gateDisabledTestEnv) != "1" {
+		runWithGateDisabled(t, "TestValidateAuthServerURL_GateDisabled")
+		return
+	}
+
+	require.False(t, gateS2IAMRequireHTTPS.Enabled())
+
+	_, err := validateAuthServerURL("http://example.com/auth/iam/api", false)
+	require.NoError(t, err)
+
+	_, err = validateAuthServerURL("ftp://example.com/auth/iam/api", false)
+	require.NoError(t, err)
+}
+
 func TestGetJWT_HTTPURLEnforcement(t *testing.T) {
 	t.Parallel()
+	require.True(t, gateS2IAMRequireHTTPS.Enabled())
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]string{"jwt": "header.payload.sig"})
@@ -52,4 +131,25 @@ func TestGetJWT_HTTPURLEnforcement(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "header.payload.sig", token)
 	})
+}
+
+func TestGetJWT_HTTPAllowedWhenGateDisabled(t *testing.T) {
+	if os.Getenv(gateDisabledTestEnv) != "1" {
+		runWithGateDisabled(t, "TestGetJWT_HTTPAllowedWhenGateDisabled")
+		return
+	}
+
+	require.False(t, gateS2IAMRequireHTTPS.Enabled())
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"jwt": "header.payload.sig"})
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL := server.URL + "/auth/iam/:jwtType"
+	stub := httpsTestStubProvider{}
+
+	token, err := GetAPIJWT(context.Background(), WithServerURL(serverURL), WithProvider(stub))
+	require.NoError(t, err)
+	assert.Equal(t, "header.payload.sig", token)
 }

--- a/go/s2iam/https_test.go
+++ b/go/s2iam/https_test.go
@@ -1,8 +1,13 @@
 package s2iam
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/singlestore-labs/singlestore-auth-iam/go/s2iam/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -57,4 +62,46 @@ func TestGetAPIJWT_RejectsHTTPWithoutAllowHTTP(t *testing.T) {
 	_, err := GetAPIJWT(t.Context(), WithServerURL("http://localhost:8080/auth/iam/:jwtType"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "authentication server URL must use HTTPS")
+}
+
+type httpsTestStubProvider struct{}
+
+func (httpsTestStubProvider) Detect(context.Context) error { return nil }
+func (httpsTestStubProvider) FastDetect() error            { return nil }
+func (httpsTestStubProvider) GetType() models.CloudProviderType {
+	return models.ProviderAWS
+}
+func (p httpsTestStubProvider) AssumeRole(string) models.CloudProviderClient { return p }
+func (httpsTestStubProvider) GetIdentityHeaders(context.Context, map[string]string) (map[string]string, *models.CloudIdentity, error) {
+	return map[string]string{"X-Stub": "1"}, &models.CloudIdentity{
+		Provider:   models.ProviderAWS,
+		Identifier: "arn:aws:iam::123456789012:role/test",
+	}, nil
+}
+
+func TestGetJWT_HTTPURLEnforcement(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"jwt": "header.payload.sig"})
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL := server.URL + "/auth/iam/:jwtType"
+	stub := httpsTestStubProvider{}
+	ctx := t.Context()
+
+	t.Run("rejects http without allowHTTP", func(t *testing.T) {
+		t.Parallel()
+		_, err := GetAPIJWT(ctx, WithServerURL(serverURL), WithProvider(stub))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "authentication server URL must use HTTPS")
+	})
+
+	t.Run("allows http with allowHTTP", func(t *testing.T) {
+		t.Parallel()
+		token, err := GetAPIJWT(ctx, WithServerURL(serverURL), WithAllowHTTP(), WithProvider(stub))
+		require.NoError(t, err)
+		assert.Equal(t, "header.payload.sig", token)
+	})
 }

--- a/go/s2iam/https_test.go
+++ b/go/s2iam/https_test.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/singlestore-labs/singlestore-auth-iam/go/s2iam/models"
@@ -29,85 +27,8 @@ func (httpsTestStubProvider) GetIdentityHeaders(context.Context, map[string]stri
 	}, nil
 }
 
-const gateDisabledTestEnv = "S2IAM_REQUIRE_HTTPS_GATE_DISABLED_TEST"
-
-func runWithGateDisabled(t *testing.T, testName string) {
-	t.Helper()
-	cmd := exec.Command(os.Args[0], "-test.run=^"+testName+"$", "-test.count=1", "-test.parallel=1")
-	cmd.Env = append(os.Environ(), "DISABLE_CODE_S2IAMRequireHTTPS=1", gateDisabledTestEnv+"=1")
-	out, err := cmd.CombinedOutput()
-	require.NoError(t, err, "subprocess output:\n%s", out)
-}
-
-func TestValidateAuthServerURL(t *testing.T) {
-	t.Parallel()
-	require.True(t, gateS2IAMRequireHTTPS.Enabled())
-
-	tests := []struct {
-		name      string
-		rawURL    string
-		allowHTTP bool
-		wantErr   bool
-		errSubstr string
-	}{
-		{
-			name:      "allows https",
-			rawURL:    "https://example.com/auth/iam/api",
-			allowHTTP: false,
-		},
-		{
-			name:      "rejects http without allowHTTP",
-			rawURL:    "http://example.com/auth/iam/api",
-			allowHTTP: false,
-			wantErr:   true,
-			errSubstr: "authentication server URL must use HTTPS",
-		},
-		{
-			name:      "allows http with allowHTTP",
-			rawURL:    "http://example.com/auth/iam/api",
-			allowHTTP: true,
-		},
-		{
-			name:      "rejects non-http schemes",
-			rawURL:    "ftp://example.com/auth/iam/api",
-			allowHTTP: false,
-			wantErr:   true,
-			errSubstr: "authentication server URL must use HTTPS",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			_, err := validateAuthServerURL(tt.rawURL, tt.allowHTTP)
-			if tt.wantErr {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.errSubstr)
-				return
-			}
-			require.NoError(t, err)
-		})
-	}
-}
-
-func TestValidateAuthServerURL_GateDisabled(t *testing.T) {
-	if os.Getenv(gateDisabledTestEnv) != "1" {
-		runWithGateDisabled(t, "TestValidateAuthServerURL_GateDisabled")
-		return
-	}
-
-	require.False(t, gateS2IAMRequireHTTPS.Enabled())
-
-	_, err := validateAuthServerURL("http://example.com/auth/iam/api", false)
-	require.NoError(t, err)
-
-	_, err = validateAuthServerURL("ftp://example.com/auth/iam/api", false)
-	require.NoError(t, err)
-}
-
 func TestGetJWT_HTTPURLEnforcement(t *testing.T) {
 	t.Parallel()
-	require.True(t, gateS2IAMRequireHTTPS.Enabled())
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]string{"jwt": "header.payload.sig"})
@@ -131,25 +52,4 @@ func TestGetJWT_HTTPURLEnforcement(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "header.payload.sig", token)
 	})
-}
-
-func TestGetJWT_HTTPAllowedWhenGateDisabled(t *testing.T) {
-	if os.Getenv(gateDisabledTestEnv) != "1" {
-		runWithGateDisabled(t, "TestGetJWT_HTTPAllowedWhenGateDisabled")
-		return
-	}
-
-	require.False(t, gateS2IAMRequireHTTPS.Enabled())
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]string{"jwt": "header.payload.sig"})
-	}))
-	t.Cleanup(server.Close)
-
-	serverURL := server.URL + "/auth/iam/:jwtType"
-	stub := httpsTestStubProvider{}
-
-	token, err := GetAPIJWT(context.Background(), WithServerURL(serverURL), WithProvider(stub))
-	require.NoError(t, err)
-	assert.Equal(t, "header.payload.sig", token)
 }

--- a/go/s2iam/https_test.go
+++ b/go/s2iam/https_test.go
@@ -12,58 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidateAuthServerURL(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name      string
-		rawURL    string
-		allowHTTP bool
-		wantErr   string
-	}{
-		{
-			name:   "https allowed by default",
-			rawURL: "https://authsvc.singlestore.com/auth/iam/database",
-		},
-		{
-			name:      "http allowed when opted in",
-			rawURL:    "http://localhost:8080/auth/iam/database",
-			allowHTTP: true,
-		},
-		{
-			name:    "http rejected by default",
-			rawURL:  "http://localhost:8080/auth/iam/database",
-			wantErr: "authentication server URL must use HTTPS",
-		},
-		{
-			name:    "unsupported scheme rejected",
-			rawURL:  "ftp://example.com/auth/iam/database",
-			wantErr: "authentication server URL must use HTTPS",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			_, err := validateAuthServerURL(tt.rawURL, tt.allowHTTP)
-			if tt.wantErr == "" {
-				require.NoError(t, err)
-				return
-			}
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tt.wantErr)
-		})
-	}
-}
-
-func TestGetAPIJWT_RejectsHTTPWithoutAllowHTTP(t *testing.T) {
-	t.Parallel()
-
-	_, err := GetAPIJWT(context.Background(), WithServerURL("http://localhost:8080/auth/iam/:jwtType"))
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "authentication server URL must use HTTPS")
-}
-
 type httpsTestStubProvider struct{}
 
 func (httpsTestStubProvider) Detect(context.Context) error { return nil }

--- a/go/s2iam/https_test.go
+++ b/go/s2iam/https_test.go
@@ -59,7 +59,7 @@ func TestValidateAuthServerURL(t *testing.T) {
 func TestGetAPIJWT_RejectsHTTPWithoutAllowHTTP(t *testing.T) {
 	t.Parallel()
 
-	_, err := GetAPIJWT(t.Context(), WithServerURL("http://localhost:8080/auth/iam/:jwtType"))
+	_, err := GetAPIJWT(context.Background(), WithServerURL("http://localhost:8080/auth/iam/:jwtType"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "authentication server URL must use HTTPS")
 }
@@ -89,7 +89,7 @@ func TestGetJWT_HTTPURLEnforcement(t *testing.T) {
 
 	serverURL := server.URL + "/auth/iam/:jwtType"
 	stub := httpsTestStubProvider{}
-	ctx := t.Context()
+	ctx := context.Background()
 
 	t.Run("rejects http without allowHTTP", func(t *testing.T) {
 		t.Parallel()

--- a/go/s2iam/jwt.go
+++ b/go/s2iam/jwt.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -39,6 +38,7 @@ type jwtOptions struct {
 	JWTType              JWTType
 	WorkspaceGroupID     string
 	ServerURL            string
+	AllowHTTP            bool
 	Provider             models.CloudProviderClient
 	AdditionalParams     map[string]string
 	AssumeRoleIdentifier string
@@ -48,6 +48,13 @@ type jwtOptions struct {
 func WithServerURL(serverURL string) JWTOption {
 	return jwtOption(func(o *jwtOptions) {
 		o.ServerURL = serverURL
+	})
+}
+
+// WithAllowHTTP permits http:// authentication server URLs. Intended for local testing only.
+func WithAllowHTTP() JWTOption {
+	return jwtOption(func(o *jwtOptions) {
+		o.AllowHTTP = true
 	})
 }
 
@@ -100,6 +107,11 @@ func getJWT(ctx context.Context, defaultOpts jwtOptions, opts []JWTOption) (stri
 		return "", errors.New("server URL is required")
 	}
 
+	probeURL := strings.ReplaceAll(strings.ReplaceAll(jwtOpts.ServerURL, ":cloudProvider", "aws"), ":jwtType", string(jwtOpts.JWTType))
+	if _, err := validateAuthServerURL(probeURL, jwtOpts.AllowHTTP); err != nil {
+		return "", err
+	}
+
 	// Auto-detect provider if not specified
 	if jwtOpts.Provider == nil {
 		var err error
@@ -125,9 +137,9 @@ func getJWT(ctx context.Context, defaultOpts jwtOptions, opts []JWTOption) (stri
 	targetURL = strings.ReplaceAll(targetURL, ":cloudProvider", string(identity.Provider))
 	targetURL = strings.ReplaceAll(targetURL, ":jwtType", string(jwtOpts.JWTType))
 
-	uri, err := url.Parse(targetURL)
+	uri, err := validateAuthServerURL(targetURL, jwtOpts.AllowHTTP)
 	if err != nil {
-		return "", errors.Errorf("invalid server URL: %w", err)
+		return "", err
 	}
 
 	// Add query parameters

--- a/go/s2iam/s2iam_test.go
+++ b/go/s2iam/s2iam_test.go
@@ -211,14 +211,14 @@ func testHappyPath(t *testing.T, client s2iam.CloudProviderClient) {
 		require.NoError(t, err, "Failed to get client-side identity")
 
 		token, err = s2iam.GetDatabaseJWT(ctx, "test-workspace",
-			s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"),
+			s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"), s2iam.WithAllowHTTP(),
 			s2iam.WithGCPAudience("https://authsvc.singlestore.com"))
 	} else {
 		_, clientIdentity, err = client.GetIdentityHeaders(ctx, nil)
 		require.NoError(t, err, "Failed to get client-side identity")
 
 		token, err = s2iam.GetDatabaseJWT(ctx, "test-workspace",
-			s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"))
+			s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"), s2iam.WithAllowHTTP())
 	}
 
 	require.NoError(t, err)
@@ -299,11 +299,11 @@ func TestGetAPIJWT(t *testing.T) {
 	if client.GetType() == s2iam.ProviderGCP && (os.Getenv("S2IAM_TEST_CLOUD_PROVIDER") != "" || os.Getenv("S2IAM_TEST_ASSUME_ROLE") != "") {
 		// On real GCP, explicitly use the default audience to ensure compatibility
 		token, err = s2iam.GetAPIJWT(ctx,
-			s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"),
+			s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"), s2iam.WithAllowHTTP(),
 			s2iam.WithGCPAudience("https://authsvc.singlestore.com"))
 	} else {
 		token, err = s2iam.GetAPIJWT(ctx,
-			s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"))
+			s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"), s2iam.WithAllowHTTP())
 	}
 
 	require.NoError(t, err)
@@ -334,7 +334,7 @@ func TestGetDatabaseJWT_EmptyJWT(t *testing.T) {
 
 	ctx := context.Background()
 	_, err := s2iam.GetDatabaseJWT(ctx, "test-workspace",
-		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"))
+		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"), s2iam.WithAllowHTTP())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "received empty JWT")
@@ -350,7 +350,7 @@ func TestGetDatabaseJWT_InvalidJSON(t *testing.T) {
 
 	ctx := context.Background()
 	_, err := s2iam.GetDatabaseJWT(ctx, "test-workspace",
-		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"))
+		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"), s2iam.WithAllowHTTP())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot parse response")
@@ -366,7 +366,7 @@ func TestGetDatabaseJWT_ServerError(t *testing.T) {
 
 	ctx := context.Background()
 	_, err := s2iam.GetDatabaseJWT(ctx, "test-workspace",
-		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"))
+		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"), s2iam.WithAllowHTTP())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "authentication server returned status 500")
@@ -382,7 +382,7 @@ func TestGetDatabaseJWT_VerificationFailure(t *testing.T) {
 
 	ctx := context.Background()
 	_, err := s2iam.GetDatabaseJWT(ctx, "test-workspace",
-		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"))
+		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"), s2iam.WithAllowHTTP())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "authentication server returned status 401")
@@ -409,7 +409,7 @@ func TestGetDatabaseJWT_GCPAudience(t *testing.T) {
 
 		ctx := context.Background()
 		token, err := s2iam.GetDatabaseJWT(ctx, "test-workspace",
-			s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"),
+			s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"), s2iam.WithAllowHTTP(),
 			s2iam.WithGCPAudience("https://authsvc.singlestore.com"))
 		require.NoError(t, err)
 		require.NotEmpty(t, token)
@@ -423,7 +423,7 @@ func TestGetDatabaseJWT_GCPAudience(t *testing.T) {
 
 	ctx := context.Background()
 	token, err := s2iam.GetDatabaseJWT(ctx, "test-workspace",
-		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"),
+		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"), s2iam.WithAllowHTTP(),
 		s2iam.WithGCPAudience("https://test.example.com"))
 
 	require.NoError(t, err)
@@ -447,7 +447,7 @@ func TestGetDatabaseJWT_AssumeRole_Valid(t *testing.T) {
 
 	ctx := context.Background()
 	originalJWT, err := s2iam.GetDatabaseJWT(ctx, "test-workspace",
-		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"))
+		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"), s2iam.WithAllowHTTP())
 	require.NoError(t, err)
 	originalClaims := validateJWT(t, originalJWT)
 	originalIdentifier := originalClaims["sub"].(string)
@@ -458,7 +458,7 @@ func TestGetDatabaseJWT_AssumeRole_Valid(t *testing.T) {
 
 	// Now test with role assumption
 	assumedJWT, err := s2iam.GetDatabaseJWT(ctx, "test-workspace",
-		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"),
+		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"), s2iam.WithAllowHTTP(),
 		s2iam.WithAssumeRole(roleIdentifier))
 
 	// Since S2IAM_TEST_ASSUME_ROLE is set, role assumption MUST succeed
@@ -526,7 +526,7 @@ func TestGetDatabaseJWT_AssumeRole_InvalidRole(t *testing.T) {
 	}
 
 	_, err := s2iam.GetDatabaseJWT(ctx, "test-workspace",
-		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"),
+		s2iam.WithServerURL(fakeServer.URL+"/iam/:jwtType"), s2iam.WithAllowHTTP(),
 		s2iam.WithAssumeRole(invalidRole))
 
 	// This should fail since the role doesn't exist (or AssumeRole isn't supported)

--- a/java/src/main/java/com/singlestore/s2iam/S2IAM.java
+++ b/java/src/main/java/com/singlestore/s2iam/S2IAM.java
@@ -337,6 +337,28 @@ public final class S2IAM {
     return s;
   }
 
+  static void validateAuthServerURL(String rawUrl, boolean allowHttp) throws S2IAMException {
+    URI uri;
+    try {
+      uri = URI.create(rawUrl);
+    } catch (IllegalArgumentException e) {
+      throw new S2IAMException("invalid server URL: " + rawUrl, e);
+    }
+    String scheme = uri.getScheme();
+    if ("https".equals(scheme)) {
+      return;
+    }
+    if ("http".equals(scheme) && allowHttp) {
+      return;
+    }
+    if ("http".equals(scheme)) {
+      throw new S2IAMException(
+          "authentication server URL must use HTTPS; use Options.withAllowHttp() for testing");
+    }
+    throw new S2IAMException(
+        "authentication server URL must use HTTPS (got scheme " + scheme + ")");
+  }
+
   // Removed buildAggregateDetectMessage/formatSection in favor of simpler counts.
 
   private static void applyJwtOptions(JwtOptions o, JwtOption... opts) {
@@ -352,6 +374,8 @@ public final class S2IAM {
     if (o.serverUrl == null || o.serverUrl.isEmpty()) {
       throw new S2IAMException("server URL is required");
     }
+    String probeUrl = o.serverUrl.replace(":cloudProvider", "aws").replace(":jwtType", "database");
+    validateAuthServerURL(probeUrl, o.allowHttp);
     if (o.provider == null) {
       try {
         o.provider = detectProvider();
@@ -415,6 +439,7 @@ public final class S2IAM {
 
     String url = o.serverUrl.replace(":cloudProvider", identity.getProvider().name())
         .replace(":jwtType", o.jwtType.name());
+    validateAuthServerURL(url, o.allowHttp);
     String query = "";
     if (o.jwtType == JwtOptions.JWTType.database && o.workspaceGroupId != null
         && !o.workspaceGroupId.isEmpty()) {

--- a/java/src/main/java/com/singlestore/s2iam/S2IAM.java
+++ b/java/src/main/java/com/singlestore/s2iam/S2IAM.java
@@ -345,13 +345,13 @@ public final class S2IAM {
       throw new S2IAMException("invalid server URL: " + rawUrl, e);
     }
     String scheme = uri.getScheme();
-    if ("https".equals(scheme)) {
+    if ("https".equalsIgnoreCase(scheme)) {
       return;
     }
-    if ("http".equals(scheme) && allowHttp) {
+    if ("http".equalsIgnoreCase(scheme) && allowHttp) {
       return;
     }
-    if ("http".equals(scheme)) {
+    if ("http".equalsIgnoreCase(scheme)) {
       throw new S2IAMException(
           "authentication server URL must use HTTPS; use Options.withAllowHttp() for testing");
     }

--- a/java/src/main/java/com/singlestore/s2iam/S2IAMRequest.java
+++ b/java/src/main/java/com/singlestore/s2iam/S2IAMRequest.java
@@ -25,6 +25,7 @@ public final class S2IAMRequest {
   private String assumeRoleId;
   private Duration timeout;
   private String serverUrl;
+  private boolean allowHttp;
   private final Map<String, String> additionalParams = new LinkedHashMap<>();
   private CloudProviderClient provider; // optional explicit provider (skips detection)
 
@@ -70,6 +71,12 @@ public final class S2IAMRequest {
     return this;
   }
 
+  /** Allow http:// authentication server URLs (for testing only). */
+  public S2IAMRequest allowHttp() {
+    this.allowHttp = true;
+    return this;
+  }
+
   /**
    * Provide explicit provider (e.g., FakeProvider in tests) to skip detection.
    */
@@ -109,6 +116,8 @@ public final class S2IAMRequest {
       jwtOpts.add(Options.withAssumeRole(assumeRoleId));
     if (serverUrl != null)
       jwtOpts.add(Options.withServerUrl(serverUrl));
+    if (allowHttp)
+      jwtOpts.add(Options.withAllowHttp());
     if (timeout != null)
       providerOpts.add(Options.withTimeout(timeout));
     // Map additional params to existing explicit helpers (currently only audience)

--- a/java/src/main/java/com/singlestore/s2iam/options/JwtOptions.java
+++ b/java/src/main/java/com/singlestore/s2iam/options/JwtOptions.java
@@ -12,6 +12,7 @@ public class JwtOptions extends ProviderOptions {
   public JWTType jwtType;
   public String workspaceGroupId;
   public String serverUrl;
+  public boolean allowHttp;
   public CloudProviderClient provider;
   public Map<String, String> additionalParams = new HashMap<>();
   public String assumeRoleIdentifier;

--- a/java/src/main/java/com/singlestore/s2iam/options/Options.java
+++ b/java/src/main/java/com/singlestore/s2iam/options/Options.java
@@ -11,6 +11,10 @@ public final class Options {
     return o -> o.serverUrl = url;
   }
 
+  public static JwtOption withAllowHttp() {
+    return o -> o.allowHttp = true;
+  }
+
   public static JwtOption withProvider(CloudProviderClient provider) {
     return o -> o.provider = provider;
   }

--- a/java/src/test/java/com/singlestore/s2iam/S2IAMHttpsTest.java
+++ b/java/src/test/java/com/singlestore/s2iam/S2IAMHttpsTest.java
@@ -26,8 +26,9 @@ public class S2IAMHttpsTest {
 
   @AfterEach
   void stop() {
-    if (server != null)
+    if (server != null) {
       server.stop();
+    }
   }
 
   private String url() {
@@ -35,19 +36,7 @@ public class S2IAMHttpsTest {
   }
 
   @Test
-  void validateAuthServerURL_rejectsHttpByDefault() {
-    S2IAMException ex = assertThrows(S2IAMException.class,
-        () -> S2IAM.validateAuthServerURL("http://localhost/auth/iam/api", false));
-    assertTrue(ex.getMessage().contains("HTTPS"));
-  }
-
-  @Test
-  void validateAuthServerURL_allowsHttpWhenOptedIn() throws Exception {
-    assertDoesNotThrow(() -> S2IAM.validateAuthServerURL("http://localhost/auth/iam/api", true));
-  }
-
-  @Test
-  void getAPIJWT_rejectsHttpWithoutAllowHttp() {
+  void getJWT_rejectsHttpWithoutAllowHttp() {
     FakeProvider fake = new FakeProvider();
     S2IAMException ex = assertThrows(S2IAMException.class,
         () -> S2IAM.getAPIJWT(Options.withProvider(fake), ServerUrlOption.of(url())));
@@ -55,35 +44,10 @@ public class S2IAMHttpsTest {
   }
 
   @Test
-  void getAPIJWT_allowsHttpWithAllowHttp() throws Exception {
+  void getJWT_allowsHttpWithAllowHttp() throws Exception {
     CloudProviderClient provider = detectOrSkip();
     String jwt = S2IAM.getAPIJWT(Options.withProvider(provider), ServerUrlOption.of(url()),
         Options.withAllowHttp());
-    assertNotNull(jwt);
-    assertFalse(jwt.isEmpty());
-  }
-
-  @Test
-  void getAPIJWT_rejectsHttpWithoutAllowHttp_usingSameProviderAsAllowCase() throws Exception {
-    CloudProviderClient provider = detectOrSkip();
-    S2IAMException ex = assertThrows(S2IAMException.class,
-        () -> S2IAM.getAPIJWT(Options.withProvider(provider), ServerUrlOption.of(url())));
-    assertTrue(ex.getMessage().contains("HTTPS"));
-  }
-
-  @Test
-  void builder_rejectsHttpWithoutAllowHttp() throws Exception {
-    CloudProviderClient provider = detectOrSkip();
-    S2IAMException ex = assertThrows(S2IAMException.class,
-        () -> S2IAMRequest.newRequest().api().serverUrl(url()).provider(provider).get());
-    assertTrue(ex.getMessage().contains("HTTPS"));
-  }
-
-  @Test
-  void builder_allowsHttpWithAllowHttp() throws Exception {
-    CloudProviderClient provider = detectOrSkip();
-    String jwt = S2IAMRequest.newRequest().api().serverUrl(url()).allowHttp().provider(provider)
-        .get();
     assertNotNull(jwt);
     assertFalse(jwt.isEmpty());
   }
@@ -92,15 +56,18 @@ public class S2IAMHttpsTest {
     String expectProvider = System.getenv("S2IAM_TEST_CLOUD_PROVIDER");
     if (expectProvider == null) {
       String role = System.getenv("S2IAM_TEST_ASSUME_ROLE");
-      if (role != null && !role.isEmpty())
+      if (role != null && !role.isEmpty()) {
         expectProvider = "aws";
+      }
     }
-    if (expectProvider == null)
+    if (expectProvider == null) {
       expectProvider = System.getenv("S2IAM_TEST_CLOUD_PROVIDER_NO_ROLE");
+    }
     try {
       CloudProviderClient client = S2IAM.detectProvider();
-      if (expectProvider == null)
+      if (expectProvider == null) {
         Assumptions.abort("No cloud provider detected - not running in cloud environment");
+      }
       if (System.getenv("S2IAM_TEST_CLOUD_PROVIDER_NO_ROLE") != null
           && System.getenv("S2IAM_TEST_CLOUD_PROVIDER") == null
           && System.getenv("S2IAM_TEST_ASSUME_ROLE") == null) {
@@ -108,8 +75,9 @@ public class S2IAMHttpsTest {
       }
       return client;
     } catch (NoCloudProviderDetectedException e) {
-      if (expectProvider != null)
+      if (expectProvider != null) {
         fail("Cloud provider detection failed - expected to detect provider in test environment");
+      }
       Assumptions.abort("No cloud provider detected - skipping");
       return null;
     }
@@ -137,7 +105,8 @@ public class S2IAMHttpsTest {
     }
 
     @Override
-    public IdentityHeadersResult getIdentityHeaders(java.util.Map<String, String> additionalParams) {
+    public IdentityHeadersResult getIdentityHeaders(
+        java.util.Map<String, String> additionalParams) {
       HashMap<String, String> headers = new HashMap<>();
       headers.put("X-Test", "ok");
       CloudIdentity id = new CloudIdentity(CloudProviderType.aws,

--- a/java/src/test/java/com/singlestore/s2iam/S2IAMHttpsTest.java
+++ b/java/src/test/java/com/singlestore/s2iam/S2IAMHttpsTest.java
@@ -36,6 +36,11 @@ public class S2IAMHttpsTest {
   }
 
   @Test
+  void validateAuthServerURL_acceptsUppercaseHttps() throws Exception {
+    S2IAM.validateAuthServerURL("HTTPS://example.com/auth/iam/api", false);
+  }
+
+  @Test
   void getJWT_rejectsHttpWithoutAllowHttp() {
     FakeProvider fake = new FakeProvider();
     S2IAMException ex = assertThrows(S2IAMException.class,

--- a/java/src/test/java/com/singlestore/s2iam/S2IAMHttpsTest.java
+++ b/java/src/test/java/com/singlestore/s2iam/S2IAMHttpsTest.java
@@ -1,0 +1,149 @@
+package com.singlestore.s2iam;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.singlestore.s2iam.exceptions.NoCloudProviderDetectedException;
+import com.singlestore.s2iam.exceptions.S2IAMException;
+import com.singlestore.s2iam.options.Options;
+import com.singlestore.s2iam.options.ServerUrlOption;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Paired tests proving http:// auth server URLs require explicit opt-in. */
+public class S2IAMHttpsTest {
+  GoTestServer server;
+
+  @BeforeEach
+  void start() throws Exception {
+    server = new GoTestServer(Path.of(".").toAbsolutePath());
+    server.start();
+  }
+
+  @AfterEach
+  void stop() {
+    if (server != null)
+      server.stop();
+  }
+
+  private String url() {
+    return server.getEndpoints().getOrDefault("auth", server.getBaseURL() + "/auth/iam/:jwtType");
+  }
+
+  @Test
+  void validateAuthServerURL_rejectsHttpByDefault() {
+    S2IAMException ex = assertThrows(S2IAMException.class,
+        () -> S2IAM.validateAuthServerURL("http://localhost/auth/iam/api", false));
+    assertTrue(ex.getMessage().contains("HTTPS"));
+  }
+
+  @Test
+  void validateAuthServerURL_allowsHttpWhenOptedIn() throws Exception {
+    assertDoesNotThrow(() -> S2IAM.validateAuthServerURL("http://localhost/auth/iam/api", true));
+  }
+
+  @Test
+  void getAPIJWT_rejectsHttpWithoutAllowHttp() {
+    FakeProvider fake = new FakeProvider();
+    S2IAMException ex = assertThrows(S2IAMException.class,
+        () -> S2IAM.getAPIJWT(Options.withProvider(fake), ServerUrlOption.of(url())));
+    assertTrue(ex.getMessage().contains("HTTPS"));
+  }
+
+  @Test
+  void getAPIJWT_allowsHttpWithAllowHttp() throws Exception {
+    CloudProviderClient provider = detectOrSkip();
+    String jwt = S2IAM.getAPIJWT(Options.withProvider(provider), ServerUrlOption.of(url()),
+        Options.withAllowHttp());
+    assertNotNull(jwt);
+    assertFalse(jwt.isEmpty());
+  }
+
+  @Test
+  void getAPIJWT_rejectsHttpWithoutAllowHttp_usingSameProviderAsAllowCase() throws Exception {
+    CloudProviderClient provider = detectOrSkip();
+    S2IAMException ex = assertThrows(S2IAMException.class,
+        () -> S2IAM.getAPIJWT(Options.withProvider(provider), ServerUrlOption.of(url())));
+    assertTrue(ex.getMessage().contains("HTTPS"));
+  }
+
+  @Test
+  void builder_rejectsHttpWithoutAllowHttp() throws Exception {
+    CloudProviderClient provider = detectOrSkip();
+    S2IAMException ex = assertThrows(S2IAMException.class,
+        () -> S2IAMRequest.newRequest().api().serverUrl(url()).provider(provider).get());
+    assertTrue(ex.getMessage().contains("HTTPS"));
+  }
+
+  @Test
+  void builder_allowsHttpWithAllowHttp() throws Exception {
+    CloudProviderClient provider = detectOrSkip();
+    String jwt = S2IAMRequest.newRequest().api().serverUrl(url()).allowHttp().provider(provider)
+        .get();
+    assertNotNull(jwt);
+    assertFalse(jwt.isEmpty());
+  }
+
+  private CloudProviderClient detectOrSkip() throws Exception {
+    String expectProvider = System.getenv("S2IAM_TEST_CLOUD_PROVIDER");
+    if (expectProvider == null) {
+      String role = System.getenv("S2IAM_TEST_ASSUME_ROLE");
+      if (role != null && !role.isEmpty())
+        expectProvider = "aws";
+    }
+    if (expectProvider == null)
+      expectProvider = System.getenv("S2IAM_TEST_CLOUD_PROVIDER_NO_ROLE");
+    try {
+      CloudProviderClient client = S2IAM.detectProvider();
+      if (expectProvider == null)
+        Assumptions.abort("No cloud provider detected - not running in cloud environment");
+      if (System.getenv("S2IAM_TEST_CLOUD_PROVIDER_NO_ROLE") != null
+          && System.getenv("S2IAM_TEST_CLOUD_PROVIDER") == null
+          && System.getenv("S2IAM_TEST_ASSUME_ROLE") == null) {
+        Assumptions.abort("No-role environment - skipping JWT HTTPS allow tests");
+      }
+      return client;
+    } catch (NoCloudProviderDetectedException e) {
+      if (expectProvider != null)
+        fail("Cloud provider detection failed - expected to detect provider in test environment");
+      Assumptions.abort("No cloud provider detected - skipping");
+      return null;
+    }
+  }
+
+  static final class FakeProvider implements CloudProviderClient {
+    @Override
+    public CloudProviderType getType() {
+      return CloudProviderType.aws;
+    }
+
+    @Override
+    public CloudProviderClient assumeRole(String roleIdentifier) {
+      return this;
+    }
+
+    @Override
+    public Exception fastDetect() {
+      return null;
+    }
+
+    @Override
+    public Exception detect() {
+      return null;
+    }
+
+    @Override
+    public IdentityHeadersResult getIdentityHeaders(java.util.Map<String, String> additionalParams) {
+      HashMap<String, String> headers = new HashMap<>();
+      headers.put("X-Test", "ok");
+      CloudIdentity id = new CloudIdentity(CloudProviderType.aws,
+          "arn:aws:iam::123456789012:role/test", "123456789012", "us-east-1", "aws-role",
+          Collections.emptyMap());
+      return new IdentityHeadersResult(headers, id, null);
+    }
+  }
+}

--- a/java/src/test/java/com/singlestore/s2iam/S2IAMIdentityShapeTest.java
+++ b/java/src/test/java/com/singlestore/s2iam/S2IAMIdentityShapeTest.java
@@ -82,6 +82,7 @@ public class S2IAMIdentityShapeTest {
     List<JwtOption> opts = new ArrayList<>();
     opts.add(ServerUrlOption.of(
         server.getEndpoints().getOrDefault("auth", server.getBaseURL() + "/auth/iam/:jwtType")));
+    opts.add(Options.withAllowHttp());
     if (provider.getType() == CloudProviderType.gcp)
       opts.add(Options.withAudience("https://authsvc.singlestore.com"));
     String jwt = S2IAM.getDatabaseJWT("test-workspace", opts.toArray(new JwtOption[0]));

--- a/java/src/test/java/com/singlestore/s2iam/S2IAMJwtAssumeRoleTest.java
+++ b/java/src/test/java/com/singlestore/s2iam/S2IAMJwtAssumeRoleTest.java
@@ -54,6 +54,7 @@ public class S2IAMJwtAssumeRoleTest {
     List<JwtOption> opts = new ArrayList<>();
     opts.add(ServerUrlOption.of(
         server.getEndpoints().getOrDefault("auth", server.getBaseURL() + "/auth/iam/:jwtType")));
+    opts.add(Options.withAllowHttp());
     if (base.getType() == CloudProviderType.gcp)
       opts.add(Options.withAudience("https://authsvc.singlestore.com"));
     String originalJwt = S2IAM.getDatabaseJWT("test-workspace", opts.toArray(new JwtOption[0]));

--- a/java/src/test/java/com/singlestore/s2iam/S2IAMJwtErrorCasesTest.java
+++ b/java/src/test/java/com/singlestore/s2iam/S2IAMJwtErrorCasesTest.java
@@ -6,6 +6,7 @@ import com.singlestore.s2iam.exceptions.NoCloudProviderDetectedException;
 import com.singlestore.s2iam.exceptions.IdentityUnavailableException;
 import com.singlestore.s2iam.exceptions.S2IAMException;
 import com.singlestore.s2iam.options.ServerUrlOption;
+import com.singlestore.s2iam.options.Options;
 import java.nio.file.Path;
 import org.junit.jupiter.api.*;
 
@@ -51,7 +52,7 @@ public class S2IAMJwtErrorCasesTest {
     base = new GoTestServer(Path.of(".").toAbsolutePath(), "-return-empty-jwt");
     base.start();
     S2IAMException ex = assertThrows(S2IAMException.class,
-        () -> S2IAM.getDatabaseJWT("wg", ServerUrlOption.of(url())));
+        () -> S2IAM.getDatabaseJWT("wg", ServerUrlOption.of(url()), Options.withAllowHttp()));
     assertTrue(ex.getMessage().contains("empty"));
   }
 
@@ -77,7 +78,7 @@ public class S2IAMJwtErrorCasesTest {
     base = new GoTestServer(Path.of(".").toAbsolutePath(), "-return-error", "-error-code", "500");
     base.start();
     S2IAMException ex = assertThrows(S2IAMException.class,
-        () -> S2IAM.getAPIJWT(ServerUrlOption.of(url())));
+        () -> S2IAM.getAPIJWT(ServerUrlOption.of(url()), Options.withAllowHttp()));
     assertTrue(ex.getMessage().contains("500"));
   }
 

--- a/java/src/test/java/com/singlestore/s2iam/S2IAMJwtHappyPathTest.java
+++ b/java/src/test/java/com/singlestore/s2iam/S2IAMJwtHappyPathTest.java
@@ -144,8 +144,7 @@ public class S2IAMJwtHappyPathTest {
     String jwt = S2IAM.getDatabaseJWT("wg-test",
         ServerUrlOption.of(
             server.getEndpoints().getOrDefault("auth", server.getBaseURL() + "/auth/iam/:jwtType")),
-        Options.withAllowHttp(),
-        Options.withAudience(audience));
+        Options.withAllowHttp(), Options.withAudience(audience));
     assertNotNull(jwt);
     assertFalse(jwt.isEmpty());
   }

--- a/java/src/test/java/com/singlestore/s2iam/S2IAMJwtHappyPathTest.java
+++ b/java/src/test/java/com/singlestore/s2iam/S2IAMJwtHappyPathTest.java
@@ -65,6 +65,7 @@ public class S2IAMJwtHappyPathTest {
     // includes :jwtType
     opts.add(ServerUrlOption.of(
         server.getEndpoints().getOrDefault("auth", server.getBaseURL() + "/auth/iam/:jwtType")));
+    opts.add(Options.withAllowHttp());
     if (provider.getType() == CloudProviderType.gcp && realCloud)
       opts.add(Options.withAudience("https://authsvc.singlestore.com"));
     String jwt = S2IAM.getDatabaseJWT("wg-test", opts.toArray(new JwtOption[0]));
@@ -106,6 +107,7 @@ public class S2IAMJwtHappyPathTest {
     java.util.List<JwtOption> opts = new java.util.ArrayList<>();
     opts.add(ServerUrlOption.of(
         server.getEndpoints().getOrDefault("auth", server.getBaseURL() + "/auth/iam/:jwtType")));
+    opts.add(Options.withAllowHttp());
     if (provider.getType() == CloudProviderType.gcp && realCloud)
       opts.add(Options.withAudience("https://authsvc.singlestore.com"));
     String jwt = S2IAM.getAPIJWT(opts.toArray(new JwtOption[0]));
@@ -142,6 +144,7 @@ public class S2IAMJwtHappyPathTest {
     String jwt = S2IAM.getDatabaseJWT("wg-test",
         ServerUrlOption.of(
             server.getEndpoints().getOrDefault("auth", server.getBaseURL() + "/auth/iam/:jwtType")),
+        Options.withAllowHttp(),
         Options.withAudience(audience));
     assertNotNull(jwt);
     assertFalse(jwt.isEmpty());
@@ -150,7 +153,7 @@ public class S2IAMJwtHappyPathTest {
   @Test
   void missingWorkspaceGroupId() {
     S2IAMException ex = assertThrows(S2IAMException.class, () -> S2IAM.getDatabaseJWT("",
-        ServerUrlOption.of(server.getBaseURL() + "/auth/iam/:jwtType")));
+        ServerUrlOption.of(server.getBaseURL() + "/auth/iam/:jwtType"), Options.withAllowHttp()));
     assertTrue(ex.getMessage().contains("workspaceGroupId"));
   }
 

--- a/java/src/test/java/com/singlestore/s2iam/S2IAMRequestBuilderTest.java
+++ b/java/src/test/java/com/singlestore/s2iam/S2IAMRequestBuilderTest.java
@@ -36,7 +36,7 @@ public class S2IAMRequestBuilderTest {
   void databaseJwtViaBuilder() throws Exception {
     CloudProviderClient provider = detectOrSkip();
     S2IAMRequest req = S2IAMRequest.newRequest().databaseWorkspaceGroup("wg-test").serverUrl(url())
-        .timeout(java.time.Duration.ofSeconds(3));
+        .allowHttp().timeout(java.time.Duration.ofSeconds(3));
     boolean realCloud = System.getenv("S2IAM_TEST_CLOUD_PROVIDER") != null
         || System.getenv("S2IAM_TEST_ASSUME_ROLE") != null
         || System.getenv("S2IAM_TEST_CLOUD_PROVIDER_NO_ROLE") != null;
@@ -53,7 +53,7 @@ public class S2IAMRequestBuilderTest {
   @Test
   void apiJwtViaBuilder() throws Exception {
     CloudProviderClient provider = detectOrSkip();
-    S2IAMRequest req = S2IAMRequest.newRequest().api().serverUrl(url());
+    S2IAMRequest req = S2IAMRequest.newRequest().api().serverUrl(url()).allowHttp();
     boolean realCloud = System.getenv("S2IAM_TEST_CLOUD_PROVIDER") != null
         || System.getenv("S2IAM_TEST_ASSUME_ROLE") != null
         || System.getenv("S2IAM_TEST_CLOUD_PROVIDER_NO_ROLE") != null;

--- a/python/src/s2iam/api.py
+++ b/python/src/s2iam/api.py
@@ -12,11 +12,7 @@ from typing import Any, Dict, List, NoReturn, Optional
 from .aws import new_client as new_aws_client
 from .azure import new_client as new_azure_client
 from .gcp import new_client as new_gcp_client
-from .models import (
-    CloudProviderClient,
-    CloudProviderNotFound,
-    Logger,
-)
+from .models import CloudProviderClient, CloudProviderNotFound, Logger
 
 DETECT_PROVIDER_DEFAULT_TIMEOUT: float = 10.0
 """Default timeout (seconds) for provider detection.

--- a/python/src/s2iam/https.py
+++ b/python/src/s2iam/https.py
@@ -1,0 +1,18 @@
+"""HTTPS validation for authentication server URLs."""
+
+from urllib.parse import urlparse
+
+
+def validate_auth_server_url(raw_url: str, *, allow_http: bool = False) -> None:
+    """Ensure the authentication server URL uses HTTPS unless allow_http is set."""
+    parsed = urlparse(raw_url)
+    scheme = parsed.scheme
+    if scheme == "https":
+        return
+    if scheme == "http" and allow_http:
+        return
+    if scheme == "http":
+        raise ValueError(
+            "authentication server URL must use HTTPS; pass allow_http=True for testing"
+        )
+    raise ValueError(f"authentication server URL must use HTTPS (got scheme {scheme!r})")

--- a/python/src/s2iam/https.py
+++ b/python/src/s2iam/https.py
@@ -12,7 +12,5 @@ def validate_auth_server_url(raw_url: str, *, allow_http: bool = False) -> None:
     if scheme == "http" and allow_http:
         return
     if scheme == "http":
-        raise ValueError(
-            "authentication server URL must use HTTPS; pass allow_http=True for testing"
-        )
+        raise ValueError("authentication server URL must use HTTPS; pass allow_http=True for testing")
     raise ValueError(f"authentication server URL must use HTTPS (got scheme {scheme!r})")

--- a/python/src/s2iam/jwt.py
+++ b/python/src/s2iam/jwt.py
@@ -19,6 +19,7 @@ async def get_jwt(
     jwt_type: JWTType,
     workspace_group_id: Optional[str] = None,
     server_url: Optional[str] = None,
+    allow_http: bool = False,
     provider: Optional[CloudProviderClient] = None,
     additional_params: Optional[dict[str, str]] = None,
     assume_role_identifier: Optional[str] = None,
@@ -47,6 +48,19 @@ async def get_jwt(
         NoCloudProviderDetectedError: If no cloud provider is detected
         Exception: If JWT acquisition fails
     """
+    import os
+
+    env_server_url = os.environ.get("S2IAM_JWT_SERVER_URL")
+    if server_url is None:
+        if env_server_url:
+            server_url = env_server_url
+        else:
+            server_url = DEFAULT_SERVER_URL.format(jwt_type=jwt_type.value)
+
+    from .https import validate_auth_server_url
+
+    validate_auth_server_url(server_url, allow_http=allow_http)
+
     # Detect provider if not provided
     if provider is None:
         # Import here to avoid circular import
@@ -60,16 +74,6 @@ async def get_jwt(
 
     # Get identity headers
     headers, identity = await provider.get_identity_headers(additional_params)
-
-    # Prepare server URL, allow override via environment variable
-    import os
-
-    env_server_url = os.environ.get("S2IAM_JWT_SERVER_URL")
-    if server_url is None:
-        if env_server_url:
-            server_url = env_server_url
-        else:
-            server_url = DEFAULT_SERVER_URL.format(jwt_type=jwt_type.value)
 
     # Prepare request body
     request_data = {
@@ -122,6 +126,7 @@ async def get_jwt(
 async def get_jwt_database(
     workspace_group_id: Optional[str] = None,
     server_url: str = "https://authsvc.singlestore.com/auth/iam/database",
+    allow_http: bool = False,
     provider: Optional[CloudProviderClient] = None,
     additional_params: Optional[dict[str, str]] = None,
     assume_role_identifier: Optional[str] = None,
@@ -149,6 +154,7 @@ async def get_jwt_database(
         jwt_type=JWTType.DATABASE_ACCESS,
         workspace_group_id=workspace_group_id,
         server_url=server_url,
+        allow_http=allow_http,
         provider=provider,
         additional_params=additional_params,
         assume_role_identifier=assume_role_identifier,
@@ -161,6 +167,7 @@ async def get_jwt_database(
 async def get_jwt_api(
     workspace_group_id: Optional[str] = None,
     server_url: str = "https://authsvc.singlestore.com/auth/iam/api",
+    allow_http: bool = False,
     provider: Optional[CloudProviderClient] = None,
     additional_params: Optional[dict[str, str]] = None,
     assume_role_identifier: Optional[str] = None,
@@ -187,6 +194,7 @@ async def get_jwt_api(
         jwt_type=JWTType.API_GATEWAY_ACCESS,
         workspace_group_id=workspace_group_id,
         server_url=server_url,
+        allow_http=allow_http,
         provider=provider,
         additional_params=additional_params,
         assume_role_identifier=assume_role_identifier,

--- a/python/src/s2iam/jwt.py
+++ b/python/src/s2iam/jwt.py
@@ -6,11 +6,7 @@ from typing import Any, Optional
 
 import aiohttp
 
-from .models import (
-    CloudProviderClient,
-    JWTType,
-    Logger,
-)
+from .models import CloudProviderClient, JWTType, Logger
 
 DEFAULT_SERVER_URL = "https://authsvc.singlestore.com/auth/iam/{jwt_type}"
 

--- a/python/src/s2iam/jwt.py
+++ b/python/src/s2iam/jwt.py
@@ -35,6 +35,7 @@ async def get_jwt(
             Only used for database JWTs. When None, the JWT may have broader access.
         timeout (float): Timeout in seconds for the request
         server_url (Optional[str]): Override the default server URL
+        allow_http (bool): Permit http:// server URLs (for local testing only; default False)
         logger (Optional[Logger]): Logger instance for debug output
 
     Returns:
@@ -136,6 +137,7 @@ async def get_jwt_database(
     Args:
         workspace_group_id: Workspace group ID (optional - can be None or empty string)
         server_url: Authentication server URL (defaults to production)
+        allow_http: Permit http:// server URLs (for local testing only; default False)
         provider: Optional provider client (will auto-detect if not provided)
         additional_params: Additional provider-specific parameters
         assume_role_identifier: Role to assume before getting JWT
@@ -176,6 +178,7 @@ async def get_jwt_api(
 
     Args:
         server_url: Authentication server URL (defaults to production)
+        allow_http: Permit http:// server URLs (for local testing only; default False)
         provider: Optional provider client (will auto-detect if not provided)
         additional_params: Additional provider-specific parameters
         assume_role_identifier: Role to assume before getting JWT

--- a/python/tests/test_cloud_validation.py
+++ b/python/tests/test_cloud_validation.py
@@ -59,7 +59,6 @@ class TestHappyPath:
             provider,
             workspace_group_id="test-workspace",
             server_url=f"{test_server.server_url}/auth/iam/database",
-            allow_http=True,
             audience=audience,
         )
         provider_type = provider.get_type()
@@ -123,7 +122,6 @@ class TestProviderSpecificIntegration:
                 jwt_type=JWTType.DATABASE_ACCESS,
                 server_url=f"{test_server.server_url}/auth/iam/database",
                 allow_http=True,
-            allow_http=True,
                 provider=provider,
                 workspace_group_id="test-workspace",
             )
@@ -169,7 +167,6 @@ class TestProviderSpecificIntegration:
                 jwt_type=JWTType.DATABASE_ACCESS,
                 server_url=f"{test_server.server_url}/auth/iam/database",
                 allow_http=True,
-            allow_http=True,
                 provider=provider,
                 workspace_group_id="test-workspace",
             )

--- a/python/tests/test_cloud_validation.py
+++ b/python/tests/test_cloud_validation.py
@@ -59,6 +59,7 @@ class TestHappyPath:
             provider,
             workspace_group_id="test-workspace",
             server_url=f"{test_server.server_url}/auth/iam/database",
+            allow_http=True,
             audience=audience,
         )
         provider_type = provider.get_type()
@@ -121,6 +122,8 @@ class TestProviderSpecificIntegration:
             jwt = await s2iam.get_jwt(
                 jwt_type=JWTType.DATABASE_ACCESS,
                 server_url=f"{test_server.server_url}/auth/iam/database",
+                allow_http=True,
+            allow_http=True,
                 provider=provider,
                 workspace_group_id="test-workspace",
             )
@@ -165,6 +168,8 @@ class TestProviderSpecificIntegration:
             jwt = await s2iam.get_jwt(
                 jwt_type=JWTType.DATABASE_ACCESS,
                 server_url=f"{test_server.server_url}/auth/iam/database",
+                allow_http=True,
+            allow_http=True,
                 provider=provider,
                 workspace_group_id="test-workspace",
             )
@@ -217,6 +222,7 @@ class TestErrorHandlingValidation:
                 await s2iam.get_jwt(
                     jwt_type=JWTType.DATABASE_ACCESS,
                     server_url="http://invalid-server-url:9999/invalid",
+                    allow_http=True,
                     provider=provider,
                     timeout=5.0,
                 )

--- a/python/tests/test_fastpath.py
+++ b/python/tests/test_fastpath.py
@@ -122,7 +122,6 @@ class TestFastPathDetection:
                 fastpath_provider,
                 workspace_group_id="test-workspace",
                 server_url=f"{server.server_url}/auth/iam/database",
-                allow_http=True,
                 audience=audience,
             )
             # Cross-check that fast-path identity matches normal detection identity on critical fields

--- a/python/tests/test_fastpath.py
+++ b/python/tests/test_fastpath.py
@@ -122,6 +122,7 @@ class TestFastPathDetection:
                 fastpath_provider,
                 workspace_group_id="test-workspace",
                 server_url=f"{server.server_url}/auth/iam/database",
+                allow_http=True,
                 audience=audience,
             )
             # Cross-check that fast-path identity matches normal detection identity on critical fields

--- a/python/tests/test_https.py
+++ b/python/tests/test_https.py
@@ -1,0 +1,21 @@
+import pytest
+
+from s2iam.https import validate_auth_server_url
+
+
+def test_validate_auth_server_url_https():
+    validate_auth_server_url("https://authsvc.singlestore.com/auth/iam/database")
+
+
+def test_validate_auth_server_url_http_with_opt_in():
+    validate_auth_server_url("http://localhost:8080/auth/iam/database", allow_http=True)
+
+
+def test_validate_auth_server_url_rejects_http_by_default():
+    with pytest.raises(ValueError, match="authentication server URL must use HTTPS"):
+        validate_auth_server_url("http://localhost:8080/auth/iam/database")
+
+
+def test_validate_auth_server_url_rejects_unsupported_scheme():
+    with pytest.raises(ValueError, match="authentication server URL must use HTTPS"):
+        validate_auth_server_url("ftp://example.com/auth/iam/database")

--- a/python/tests/test_https.py
+++ b/python/tests/test_https.py
@@ -1,6 +1,35 @@
+"""Tests for HTTPS enforcement on authentication server URLs."""
+
+from typing import Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
 from s2iam.https import validate_auth_server_url
+from s2iam.jwt import get_jwt
+from s2iam.models import CloudIdentity, CloudProviderClient, CloudProviderType, JWTType
+
+
+class _StubProvider(CloudProviderClient):
+    async def fast_detect(self) -> None:
+        return None
+
+    async def detect(self) -> None:
+        return None
+
+    def get_type(self) -> CloudProviderType:
+        return CloudProviderType.AWS
+
+    def assume_role(self, role_identifier: str) -> CloudProviderClient:
+        return self
+
+    async def get_identity_headers(
+        self, additional_params: Optional[dict[str, str]] = None
+    ) -> tuple[dict[str, str], CloudIdentity]:
+        return {"X-Stub": "1"}, CloudIdentity(
+            provider=CloudProviderType.AWS,
+            identifier="arn:aws:iam::123456789012:role/test",
+        )
 
 
 def test_validate_auth_server_url_https():
@@ -19,3 +48,39 @@ def test_validate_auth_server_url_rejects_http_by_default():
 def test_validate_auth_server_url_rejects_unsupported_scheme():
     with pytest.raises(ValueError, match="authentication server URL must use HTTPS"):
         validate_auth_server_url("ftp://example.com/auth/iam/database")
+
+
+@pytest.mark.asyncio
+async def test_get_jwt_rejects_http_without_allow_http():
+    stub = _StubProvider()
+    with pytest.raises(ValueError, match="authentication server URL must use HTTPS"):
+        await get_jwt(
+            jwt_type=JWTType.API_GATEWAY_ACCESS,
+            server_url="http://localhost:8080/auth/iam/api",
+            provider=stub,
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_jwt_allows_http_with_allow_http():
+    stub = _StubProvider()
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(return_value={"jwt": "header.payload.sig"})
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+
+    mock_session = MagicMock()
+    mock_session.post.return_value = mock_response
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("s2iam.jwt.aiohttp.ClientSession", return_value=mock_session):
+        token = await get_jwt(
+            jwt_type=JWTType.API_GATEWAY_ACCESS,
+            server_url="http://localhost:8080/auth/iam/api",
+            allow_http=True,
+            provider=stub,
+        )
+
+    assert token == "header.payload.sig"

--- a/python/tests/test_https.py
+++ b/python/tests/test_https.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from s2iam.https import validate_auth_server_url
 from s2iam.jwt import get_jwt
 from s2iam.models import CloudIdentity, CloudProviderClient, CloudProviderType, JWTType
 
@@ -32,26 +31,8 @@ class _StubProvider(CloudProviderClient):
         )
 
 
-def test_validate_auth_server_url_https():
-    validate_auth_server_url("https://authsvc.singlestore.com/auth/iam/database")
-
-
-def test_validate_auth_server_url_http_with_opt_in():
-    validate_auth_server_url("http://localhost:8080/auth/iam/database", allow_http=True)
-
-
-def test_validate_auth_server_url_rejects_http_by_default():
-    with pytest.raises(ValueError, match="authentication server URL must use HTTPS"):
-        validate_auth_server_url("http://localhost:8080/auth/iam/database")
-
-
-def test_validate_auth_server_url_rejects_unsupported_scheme():
-    with pytest.raises(ValueError, match="authentication server URL must use HTTPS"):
-        validate_auth_server_url("ftp://example.com/auth/iam/database")
-
-
 @pytest.mark.asyncio
-async def test_get_jwt_rejects_http_without_allow_http():
+async def test_get_jwt_http_url_enforcement_rejects_http_without_allow_http():
     stub = _StubProvider()
     with pytest.raises(ValueError, match="authentication server URL must use HTTPS"):
         await get_jwt(
@@ -62,7 +43,7 @@ async def test_get_jwt_rejects_http_without_allow_http():
 
 
 @pytest.mark.asyncio
-async def test_get_jwt_allows_http_with_allow_http():
+async def test_get_jwt_http_url_enforcement_allows_http_with_allow_http():
     stub = _StubProvider()
     mock_response = AsyncMock()
     mock_response.status = 200

--- a/python/tests/test_integration.py
+++ b/python/tests/test_integration.py
@@ -89,6 +89,7 @@ class TestJWTIntegration:
             jwt = await s2iam.get_jwt(
                 jwt_type=JWTType.DATABASE_ACCESS,
                 server_url=f"{test_server.server_url}/auth/iam/database",
+                allow_http=True,
                 provider=provider,
                 workspace_group_id="test-workspace",
             )
@@ -121,6 +122,7 @@ class TestJWTIntegration:
                 jwt = await s2iam.get_jwt(
                     jwt_type=jwt_type,
                     server_url=f"{test_server.server_url}/auth/iam/{jwt_type.value}",
+                    allow_http=True,
                     provider=provider,
                     workspace_group_id="test-workspace",
                 )
@@ -242,6 +244,7 @@ class TestErrorHandling:
                 await s2iam.get_jwt(
                     jwt_type=JWTType.DATABASE_ACCESS,
                     server_url="http://invalid-server:9999/auth",
+                    allow_http=True,
                     provider=provider,
                     workspace_group_id="test",
                 )

--- a/python/tests/testhelp.py
+++ b/python/tests/testhelp.py
@@ -102,6 +102,7 @@ async def validate_identity_and_jwt(
     token = await s2iam.get_jwt_database(
         workspace_group_id=workspace_group_id,
         server_url=server_url,
+        allow_http=True,
         provider=provider,
         additional_params=additional_params,
     )


### PR DESCRIPTION
## Summary
Resolves INFOSEC-3101.

- Reject `http://` authentication server URLs unless callers opt in with `WithAllowHTTP()` (Go), `Options.withAllowHttp()` (Java), or `allow_http=True` (Python).
- Validate the server URL scheme before cloud provider detection so invalid URLs fail fast.
- Add `--allow-http` to the `s2iam` CLI for local and integration tests against `httptest` servers.
- Update Go, Java, and Python tests to pass the opt-in when using local HTTP servers; add unit tests for HTTPS enforcement.
- Bump `codecov/codecov-action` to v5.5.5 and Go `stretchr/testify` to v1.11.1.

## Test plan
- [x] Go: `cd go && go test ./...` (includes `TestValidateAuthServerURL`, `TestGetJWT_HTTPURLEnforcement`, CLI tests)
- [x] Java: `mvn test` (includes `S2IAMHttpsTest`)
- [x] Python: `pytest tests/test_https.py` and existing integration tests with `allow_http=True`
- [x] CI passes on this branch