### PR TITLE
Limit cloud provider tests to one concurrent job per host

### DIFF
--- a/.github/cloud-test-hosts.json
+++ b/.github/cloud-test-hosts.json
@@ -1,0 +1,44 @@
+[
+  {
+    "name": "aws-positive",
+    "username": "ubuntu",
+    "hostname": "ec2-18-206-180-126.compute-1.amazonaws.com",
+    "secret": "AWS_POSITIVE_KEY",
+    "env_vars": "S2IAM_TEST_ASSUME_ROLE=arn:aws:iam::503396375767:role/NoPermissionsRole"
+  },
+  {
+    "name": "aws-negative",
+    "username": "ubuntu",
+    "hostname": "ec2-35-173-183-101.compute-1.amazonaws.com",
+    "secret": "AWS_POSITIVE_KEY",
+    "env_vars": "S2IAM_TEST_CLOUD_PROVIDER_NO_ROLE=aws"
+  },
+  {
+    "name": "azure-positive",
+    "username": "azureuser",
+    "hostname": "52.186.98.155",
+    "secret": "AZURE_POSITIVE_KEY",
+    "env_vars": "S2IAM_TEST_CLOUD_PROVIDER=azure"
+  },
+  {
+    "name": "azure-negative",
+    "username": "azureuser",
+    "hostname": "74.235.105.73",
+    "secret": "AZURE_NEGATIVE_KEY",
+    "env_vars": "S2IAM_TEST_CLOUD_PROVIDER_NO_ROLE=azure"
+  },
+  {
+    "name": "gcp-positive",
+    "username": "dsharnoff",
+    "hostname": "34.145.164.5",
+    "secret": "GCP_POSITIVE_KEY",
+    "env_vars": "S2IAM_TEST_CLOUD_PROVIDER=gcp"
+  },
+  {
+    "name": "gcp-negative",
+    "username": "dsharnoff",
+    "hostname": "34.21.55.72",
+    "secret": "GCP_POSITIVE_KEY",
+    "env_vars": "S2IAM_TEST_CLOUD_PROVIDER_NO_ROLE=gcp"
+  }
+]

--- a/.github/workflows/cloud_clear_stale_locks.yml
+++ b/.github/workflows/cloud_clear_stale_locks.yml
@@ -1,0 +1,88 @@
+name: Clear Cloud Test Locks
+
+# Manually clear stale per-host locks on cloud test VMs when a Cloud Provider Tests
+# run did not release its lock (runner kill, network drop, etc.). Locks live at
+# /tmp/s2iam-cloud-test.lock.d/ on each VM (see Makefile ssh-clear-lock).
+#
+# Trigger: Actions → Clear Cloud Test Locks → Run workflow.
+# Leave hostname empty to clear all matrix hosts, or set one hostname to clear only that host.
+
+on:
+  workflow_dispatch:
+    inputs:
+      hostname:
+        description: 'Clear lock on this host only (empty = all cloud test VMs)'
+        required: false
+        default: ''
+
+run-name: Clear cloud test locks${{ github.event.inputs.hostname != '' && format(' ({0})', github.event.inputs.hostname) || '' }}
+
+permissions:
+  contents: read
+
+jobs:
+  clear-stale-locks:
+    runs-on: ubuntu-latest
+    environment: cloud-VMs
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: aws-positive
+            username: ubuntu
+            hostname: ec2-18-206-180-126.compute-1.amazonaws.com
+            secret: AWS_POSITIVE_KEY
+          - name: aws-negative
+            username: ubuntu
+            hostname: ec2-35-173-183-101.compute-1.amazonaws.com
+            secret: AWS_POSITIVE_KEY
+          - name: azure-positive
+            username: azureuser
+            hostname: 52.186.98.155
+            secret: AZURE_POSITIVE_KEY
+          - name: azure-negative
+            username: azureuser
+            hostname: 74.235.105.73
+            secret: AZURE_NEGATIVE_KEY
+          - name: gcp-positive
+            username: dsharnoff
+            hostname: 34.145.164.5
+            secret: GCP_POSITIVE_KEY
+          - name: gcp-negative
+            username: dsharnoff
+            hostname: 34.21.55.72
+            secret: GCP_POSITIVE_KEY
+
+    env:
+      SSH_KEY_SECRET: ${{ matrix.secret }}
+      SSH_OPTS: "-i ~/.ssh/key -o StrictHostKeyChecking=no -o ConnectTimeout=10"
+      HOST: ${{ matrix.username }}@${{ matrix.hostname }}
+
+    steps:
+    - name: Checkout repository
+      if: github.event.inputs.hostname == '' || github.event.inputs.hostname == matrix.hostname
+      uses: actions/checkout@v5
+
+    - name: Skip host not selected
+      if: github.event.inputs.hostname != '' && github.event.inputs.hostname != matrix.hostname
+      run: echo "Skipping ${{ matrix.hostname }} (not selected)" && exit 0
+
+    - name: Setup SSH key
+      if: github.event.inputs.hostname == '' || github.event.inputs.hostname == matrix.hostname
+      run: |
+        mkdir -p ~/.ssh
+        echo "${{ secrets[env.SSH_KEY_SECRET] }}" > ~/.ssh/key
+        chmod 600 ~/.ssh/key
+        ssh-keyscan -H ${{ matrix.hostname }} >> ~/.ssh/known_hosts
+        ssh ${{ env.SSH_OPTS }} ${{ env.HOST }} "echo 'SSH connection successful'"
+
+    - name: Clear stale lock
+      if: github.event.inputs.hostname == '' || github.event.inputs.hostname == matrix.hostname
+      env:
+        LOCK_HOSTNAME: ${{ matrix.hostname }}
+      run: make ssh-clear-lock
+
+    - name: Cleanup SSH key
+      if: always() && (github.event.inputs.hostname == '' || github.event.inputs.hostname == matrix.hostname)
+      run: |
+        rm -f ~/.ssh/key

--- a/.github/workflows/cloud_clear_stale_locks.yml
+++ b/.github/workflows/cloud_clear_stale_locks.yml
@@ -4,6 +4,8 @@ name: Clear Cloud Test Locks
 # run did not release its lock (runner kill, network drop, etc.). Locks live at
 # /tmp/s2iam-cloud-test.lock.d/ on each VM (see Makefile ssh-clear-lock).
 #
+# Host list: .github/cloud-test-hosts.json (shared with cloud_provider.yml).
+#
 # Trigger: Actions → Clear Cloud Test Locks → Run workflow.
 # Leave hostname empty to clear all matrix hosts, or set one hostname to clear only that host.
 
@@ -21,37 +23,26 @@ permissions:
   contents: read
 
 jobs:
+  matrix-prep:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - id: set-matrix
+        run: |
+          matrix=$(jq -c '{include: .}' .github/cloud-test-hosts.json)
+          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+
   clear-stale-locks:
+    needs: matrix-prep
     runs-on: ubuntu-latest
     environment: cloud-VMs
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - name: aws-positive
-            username: ubuntu
-            hostname: ec2-18-206-180-126.compute-1.amazonaws.com
-            secret: AWS_POSITIVE_KEY
-          - name: aws-negative
-            username: ubuntu
-            hostname: ec2-35-173-183-101.compute-1.amazonaws.com
-            secret: AWS_POSITIVE_KEY
-          - name: azure-positive
-            username: azureuser
-            hostname: 52.186.98.155
-            secret: AZURE_POSITIVE_KEY
-          - name: azure-negative
-            username: azureuser
-            hostname: 74.235.105.73
-            secret: AZURE_NEGATIVE_KEY
-          - name: gcp-positive
-            username: dsharnoff
-            hostname: 34.145.164.5
-            secret: GCP_POSITIVE_KEY
-          - name: gcp-negative
-            username: dsharnoff
-            hostname: 34.21.55.72
-            secret: GCP_POSITIVE_KEY
+      matrix: ${{ fromJSON(needs.matrix-prep.outputs.matrix) }}
 
     env:
       SSH_KEY_SECRET: ${{ matrix.secret }}

--- a/.github/workflows/cloud_provider.yml
+++ b/.github/workflows/cloud_provider.yml
@@ -41,11 +41,11 @@ permissions:
 
 jobs:
   test:
-    # One concurrent SSH test run per physical host across all workflow runs.
-    # Concurrency is evaluated when the job queues (including while waiting for
-    # environment approval) — a known GitHub Actions limitation.
+    # Single test job with matrix over cloud VM hosts. SSH keys remain environment secrets.
+    # Per-matrix concurrency: one group for all matrix legs on this ref (not per host).
+    # Evaluated when jobs queue, including while waiting for environment approval.
     concurrency:
-      group: cloud-test-host-${{ matrix.hostname }}
+      group: cloud-provider-test-${{ github.ref }}
       cancel-in-progress: false
     runs-on: ubuntu-latest
     environment: cloud-VMs

--- a/.github/workflows/cloud_provider.yml
+++ b/.github/workflows/cloud_provider.yml
@@ -5,12 +5,6 @@ on:
     branches: [main]
   push:
     branches: [main]
-  workflow_dispatch:
-    inputs:
-      hostname:
-        description: 'Clear lock on this host only (empty = all matrix hosts)'
-        required: false
-        default: ''
 
 permissions:
   contents: read
@@ -49,12 +43,11 @@ permissions:
 # setup (post environment approval) via make ssh-acquire-lock (see Makefile).
 # Lock path on each host: /tmp/s2iam-cloud-test.lock.d/ (atomic mkdir; info file).
 # Release runs in an always() cleanup step (make ssh-release-lock). Stale locks
-# (runner kill, network drop) can be cleared via workflow_dispatch -> clear-stale-locks
-# (make ssh-clear-lock).
+# (runner kill, network drop) can be cleared via the "Clear Cloud Test Locks"
+# workflow (cloud_clear_stale_locks.yml; make ssh-clear-lock).
 
 jobs:
   test:
-    if: github.event_name != 'workflow_dispatch'
     # Single test job with matrix over cloud VM hosts. SSH keys remain environment secrets.
     # Per-host serialization uses remote locks on each VM (see header comment).
     runs-on: ubuntu-latest
@@ -185,72 +178,5 @@ jobs:
 
     - name: Cleanup SSH key
       if: always()
-      run: |
-        rm -f ~/.ssh/key
-
-  clear-stale-locks:
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    environment: cloud-VMs
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: aws-positive
-            username: ubuntu
-            hostname: ec2-18-206-180-126.compute-1.amazonaws.com
-            secret: AWS_POSITIVE_KEY
-          - name: aws-negative
-            username: ubuntu
-            hostname: ec2-35-173-183-101.compute-1.amazonaws.com
-            secret: AWS_POSITIVE_KEY
-          - name: azure-positive
-            username: azureuser
-            hostname: 52.186.98.155
-            secret: AZURE_POSITIVE_KEY
-          - name: azure-negative
-            username: azureuser
-            hostname: 74.235.105.73
-            secret: AZURE_NEGATIVE_KEY
-          - name: gcp-positive
-            username: dsharnoff
-            hostname: 34.145.164.5
-            secret: GCP_POSITIVE_KEY
-          - name: gcp-negative
-            username: dsharnoff
-            hostname: 34.21.55.72
-            secret: GCP_POSITIVE_KEY
-
-    env:
-      SSH_KEY_SECRET: ${{ matrix.secret }}
-      SSH_OPTS: "-i ~/.ssh/key -o StrictHostKeyChecking=no -o ConnectTimeout=10"
-      HOST: ${{ matrix.username }}@${{ matrix.hostname }}
-
-    steps:
-    - name: Checkout repository
-      if: github.event.inputs.hostname == '' || github.event.inputs.hostname == matrix.hostname
-      uses: actions/checkout@v5
-
-    - name: Skip host not selected
-      if: github.event.inputs.hostname != '' && github.event.inputs.hostname != matrix.hostname
-      run: echo "Skipping ${{ matrix.hostname }} (not selected)" && exit 0
-
-    - name: Setup SSH key
-      if: github.event.inputs.hostname == '' || github.event.inputs.hostname == matrix.hostname
-      run: |
-        mkdir -p ~/.ssh
-        echo "${{ secrets[env.SSH_KEY_SECRET] }}" > ~/.ssh/key
-        chmod 600 ~/.ssh/key
-        ssh-keyscan -H ${{ matrix.hostname }} >> ~/.ssh/known_hosts
-        ssh ${{ env.SSH_OPTS }} ${{ env.HOST }} "echo 'SSH connection successful'"
-
-    - name: Clear stale lock
-      if: github.event.inputs.hostname == '' || github.event.inputs.hostname == matrix.hostname
-      env:
-        LOCK_HOSTNAME: ${{ matrix.hostname }}
-      run: make ssh-clear-lock
-
-    - name: Cleanup SSH key
-      if: always() && (github.event.inputs.hostname == '' || github.event.inputs.hostname == matrix.hostname)
       run: |
         rm -f ~/.ssh/key

--- a/.github/workflows/cloud_provider.yml
+++ b/.github/workflows/cloud_provider.yml
@@ -41,6 +41,10 @@ permissions:
 
 jobs:
   test:
+    # One concurrent SSH test run per physical host across all workflow runs.
+    concurrency:
+      group: cloud-test-host-${{ matrix.hostname }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     environment: cloud-VMs
     strategy:

--- a/.github/workflows/cloud_provider.yml
+++ b/.github/workflows/cloud_provider.yml
@@ -39,25 +39,25 @@ permissions:
 # Python: Uses automated validation framework with coverage reporting (XML format)
 # Coverage from all environments (no CSP, AWS, Azure, GCP) is uploaded to Codecov
 
-# Two environments avoid double approval:
-# - cloud-VMs-gate (approve job): required reviewers only, no secrets. Create in
-#   Settings → Environments with the same reviewers as cloud-VMs if it does not exist.
-# - cloud-VMs (test job): SSH key secrets, no required reviewers (auto-proceeds after gate).
+# One manual approval per workflow run via the approve job (environment: cloud-VMs).
+# SSH keys (AWS_POSITIVE_KEY, AZURE_POSITIVE_KEY, GCP_POSITIVE_KEY) must be
+# repository secrets so the test job can access them without a second environment
+# reference (which would trigger another approval). If keys exist only on the
+# cloud-VMs environment today, copy them to Settings → Secrets and variables → Actions.
 jobs:
   approve:
-    # Single gate approval unlocks all matrix hosts for this workflow run.
+    # Single approval unlocks all matrix hosts for this workflow run.
     # Concurrency must not be acquired here; it would block other runs
     # while waiting for environment approval instead of during SSH testing.
     runs-on: ubuntu-latest
-    environment: cloud-VMs-gate
+    environment: cloud-VMs
     steps:
       - name: Approved for cloud VM testing
         run: echo "approved"
 
   test:
     needs: approve
-    # cloud-VMs supplies SSH secrets; no reviewers so test proceeds after gate approval.
-    environment: cloud-VMs
+    # No environment here — SSH keys come from repository secrets (see header).
     # One concurrent SSH test run per physical host across all workflow runs.
     concurrency:
       group: cloud-test-host-${{ matrix.hostname }}

--- a/.github/workflows/cloud_provider.yml
+++ b/.github/workflows/cloud_provider.yml
@@ -39,20 +39,24 @@ permissions:
 # Python: Uses automated validation framework with coverage reporting (XML format)
 # Coverage from all environments (no CSP, AWS, Azure, GCP) is uploaded to Codecov
 
+# Two environments avoid double approval:
+# - cloud-VMs-gate (approve job): required reviewers only, no secrets. Create in
+#   Settings → Environments with the same reviewers as cloud-VMs if it does not exist.
+# - cloud-VMs (test job): SSH key secrets, no required reviewers (auto-proceeds after gate).
 jobs:
   approve:
-    # Single approval unlocks all matrix hosts for this workflow run.
+    # Single gate approval unlocks all matrix hosts for this workflow run.
     # Concurrency must not be acquired here; it would block other runs
     # while waiting for environment approval instead of during SSH testing.
     runs-on: ubuntu-latest
-    environment: cloud-VMs
+    environment: cloud-VMs-gate
     steps:
       - name: Approved for cloud VM testing
         run: echo "approved"
 
   test:
     needs: approve
-    # cloud-VMs on test supplies SSH secrets; approve ensures approval before test jobs queue for concurrency.
+    # cloud-VMs supplies SSH secrets; no reviewers so test proceeds after gate approval.
     environment: cloud-VMs
     # One concurrent SSH test run per physical host across all workflow runs.
     concurrency:

--- a/.github/workflows/cloud_provider.yml
+++ b/.github/workflows/cloud_provider.yml
@@ -12,6 +12,8 @@ permissions:
 # Self-hosted cloud test hosts for cloud provider testing.
 # Assuming Ubuntu environment on AWS EC2, GCP Compute Engine, or Azure VM.
 #
+# Host list: .github/cloud-test-hosts.json (shared with cloud_clear_stale_locks.yml).
+#
 # Base system setup (Ubuntu hosts expected):
 # copy over the Makefile and run: make dev-setup-ubuntu
 #
@@ -47,44 +49,27 @@ permissions:
 # workflow (cloud_clear_stale_locks.yml; make ssh-clear-lock).
 
 jobs:
+  matrix-prep:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - id: set-matrix
+        run: |
+          matrix=$(jq -c '{include: .}' .github/cloud-test-hosts.json)
+          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+
   test:
     # Single test job with matrix over cloud VM hosts. SSH keys remain environment secrets.
     # Per-host serialization uses remote locks on each VM (see header comment).
+    needs: matrix-prep
     runs-on: ubuntu-latest
     environment: cloud-VMs
     strategy:
-      matrix:
-        include:
-          - name: aws-positive
-            username: ubuntu
-            hostname: ec2-18-206-180-126.compute-1.amazonaws.com
-            secret: AWS_POSITIVE_KEY
-            env_vars: "S2IAM_TEST_ASSUME_ROLE=arn:aws:iam::503396375767:role/NoPermissionsRole"
-          - name: aws-negative
-            username: ubuntu
-            hostname: ec2-35-173-183-101.compute-1.amazonaws.com
-            secret: AWS_POSITIVE_KEY
-            env_vars: "S2IAM_TEST_CLOUD_PROVIDER_NO_ROLE=aws"
-          - name: azure-positive
-            username: azureuser
-            hostname: 52.186.98.155
-            secret: AZURE_POSITIVE_KEY
-            env_vars: "S2IAM_TEST_CLOUD_PROVIDER=azure"
-          - name: azure-negative
-            username: azureuser
-            hostname: 74.235.105.73
-            secret: AZURE_NEGATIVE_KEY
-            env_vars: "S2IAM_TEST_CLOUD_PROVIDER_NO_ROLE=azure"
-          - name: gcp-positive
-            username: dsharnoff
-            hostname: 34.145.164.5
-            secret: GCP_POSITIVE_KEY
-            env_vars: "S2IAM_TEST_CLOUD_PROVIDER=gcp"
-          - name: gcp-negative
-            username: dsharnoff
-            hostname: 34.21.55.72
-            secret: GCP_POSITIVE_KEY
-            env_vars: "S2IAM_TEST_CLOUD_PROVIDER_NO_ROLE=gcp"
+      matrix: ${{ fromJSON(needs.matrix-prep.outputs.matrix) }}
 
     env:
       TEST_HOSTNAME: ${{ matrix.hostname }}

--- a/.github/workflows/cloud_provider.yml
+++ b/.github/workflows/cloud_provider.yml
@@ -52,6 +52,8 @@ jobs:
 
   test:
     needs: approve
+    # cloud-VMs on test supplies SSH secrets; approve ensures approval before test jobs queue for concurrency.
+    environment: cloud-VMs
     # One concurrent SSH test run per physical host across all workflow runs.
     concurrency:
       group: cloud-test-host-${{ matrix.hostname }}

--- a/.github/workflows/cloud_provider.yml
+++ b/.github/workflows/cloud_provider.yml
@@ -69,6 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: cloud-VMs
     strategy:
+      fail-fast: false
       matrix: ${{ fromJSON(needs.matrix-prep.outputs.matrix) }}
 
     env:

--- a/.github/workflows/cloud_provider.yml
+++ b/.github/workflows/cloud_provider.yml
@@ -46,10 +46,11 @@ permissions:
 # Coverage from all environments (no CSP, AWS, Azure, GCP) is uploaded to Codecov
 #
 # Per-host concurrency: each matrix leg acquires a remote lock on its VM after SSH
-# setup (post environment approval). Lock path on each host:
-#   /tmp/s2iam-cloud-test.lock.d/   (atomic mkdir; info file inside for debugging)
-# Release runs in an always() cleanup step. Stale locks (runner kill, network drop)
-# can be cleared via workflow_dispatch -> clear-stale-locks job.
+# setup (post environment approval) via make ssh-acquire-lock (see Makefile).
+# Lock path on each host: /tmp/s2iam-cloud-test.lock.d/ (atomic mkdir; info file).
+# Release runs in an always() cleanup step (make ssh-release-lock). Stale locks
+# (runner kill, network drop) can be cleared via workflow_dispatch -> clear-stale-locks
+# (make ssh-clear-lock).
 
 jobs:
   test:
@@ -99,7 +100,6 @@ jobs:
       EXTRA_ENV: ${{ matrix.env_vars }}
       SSH_OPTS: "-i ~/.ssh/key -o StrictHostKeyChecking=no -o ConnectTimeout=10"
       HOST: ${{ matrix.username }}@${{ matrix.hostname }}
-      LOCK_DIR: /tmp/s2iam-cloud-test.lock.d
 
     steps:
     - name: Checkout repository
@@ -115,31 +115,15 @@ jobs:
 
     - name: Acquire remote lock
       id: lock
+      env:
+        LOCK_RUN_ID: ${{ github.run_id }}
+        LOCK_RUN_ATTEMPT: ${{ github.run_attempt }}
+        LOCK_REF: ${{ github.ref }}
+        LOCK_MATRIX: ${{ matrix.name }}
+        LOCK_HOSTNAME: ${{ matrix.hostname }}
       run: |
-        set -euo pipefail
-        max_wait_seconds=7200
-        interval=30
-        elapsed=0
-        while ! ssh ${{ env.SSH_OPTS }} ${{ env.HOST }} "mkdir '${{ env.LOCK_DIR }}' 2>/dev/null"; do
-          echo "Lock held on ${{ matrix.hostname }}; waiting ${interval}s..."
-          ssh ${{ env.SSH_OPTS }} ${{ env.HOST }} "cat '${{ env.LOCK_DIR }}/info' 2>/dev/null || echo '(no lock info)'" || true
-          sleep "${interval}"
-          elapsed=$((elapsed + interval))
-          if [ "${elapsed}" -ge "${max_wait_seconds}" ]; then
-            echo "Timed out waiting for lock on ${{ matrix.hostname }} after ${max_wait_seconds}s"
-            exit 1
-          fi
-        done
-        ssh ${{ env.SSH_OPTS }} ${{ env.HOST }} "printf '%s\n' \
-          'run_id=${{ github.run_id }}' \
-          'run_attempt=${{ github.run_attempt }}' \
-          'ref=${{ github.ref }}' \
-          'matrix=${{ matrix.name }}' \
-          'hostname=${{ matrix.hostname }}' \
-          \"acquired_utc=\$(date -u +%Y-%m-%dT%H:%M:%SZ)\" \
-          > '${{ env.LOCK_DIR }}/info'"
+        make ssh-acquire-lock
         echo "acquired=true" >> "${GITHUB_OUTPUT}"
-        echo "Lock acquired on ${{ matrix.hostname }}"
 
     - name: Run remote tests via Make (copy, run, download, cleanup)
       env:
@@ -197,10 +181,7 @@ jobs:
 
     - name: Release remote lock
       if: always() && steps.lock.outputs.acquired == 'true'
-      run: |
-        set -euo pipefail
-        ssh ${{ env.SSH_OPTS }} ${{ env.HOST }} "rm -rf '${{ env.LOCK_DIR }}'"
-        echo "Lock released on ${{ matrix.hostname }}"
+      run: make ssh-release-lock
 
     - name: Cleanup SSH key
       if: always()
@@ -244,9 +225,12 @@ jobs:
       SSH_KEY_SECRET: ${{ matrix.secret }}
       SSH_OPTS: "-i ~/.ssh/key -o StrictHostKeyChecking=no -o ConnectTimeout=10"
       HOST: ${{ matrix.username }}@${{ matrix.hostname }}
-      LOCK_DIR: /tmp/s2iam-cloud-test.lock.d
 
     steps:
+    - name: Checkout repository
+      if: github.event.inputs.hostname == '' || github.event.inputs.hostname == matrix.hostname
+      uses: actions/checkout@v5
+
     - name: Skip host not selected
       if: github.event.inputs.hostname != '' && github.event.inputs.hostname != matrix.hostname
       run: echo "Skipping ${{ matrix.hostname }} (not selected)" && exit 0
@@ -262,18 +246,9 @@ jobs:
 
     - name: Clear stale lock
       if: github.event.inputs.hostname == '' || github.event.inputs.hostname == matrix.hostname
-      run: |
-        set -euo pipefail
-        ssh ${{ env.SSH_OPTS }} ${{ env.HOST }} "
-          if [ -d '${{ env.LOCK_DIR }}' ]; then
-            echo 'Stale lock on ${{ matrix.hostname }}:'
-            cat '${{ env.LOCK_DIR }}/info' 2>/dev/null || echo '(no lock info)'
-            rm -rf '${{ env.LOCK_DIR }}'
-            echo 'Lock cleared.'
-          else
-            echo 'No lock present on ${{ matrix.hostname }}.'
-          fi
-        "
+      env:
+        LOCK_HOSTNAME: ${{ matrix.hostname }}
+      run: make ssh-clear-lock
 
     - name: Cleanup SSH key
       if: always() && (github.event.inputs.hostname == '' || github.event.inputs.hostname == matrix.hostname)

--- a/.github/workflows/cloud_provider.yml
+++ b/.github/workflows/cloud_provider.yml
@@ -39,30 +39,16 @@ permissions:
 # Python: Uses automated validation framework with coverage reporting (XML format)
 # Coverage from all environments (no CSP, AWS, Azure, GCP) is uploaded to Codecov
 
-# One manual approval per workflow run via the approve job (environment: cloud-VMs).
-# SSH keys (AWS_POSITIVE_KEY, AZURE_POSITIVE_KEY, GCP_POSITIVE_KEY) must be
-# repository secrets so the test job can access them without a second environment
-# reference (which would trigger another approval). If keys exist only on the
-# cloud-VMs environment today, copy them to Settings → Secrets and variables → Actions.
 jobs:
-  approve:
-    # Single approval unlocks all matrix hosts for this workflow run.
-    # Concurrency must not be acquired here; it would block other runs
-    # while waiting for environment approval instead of during SSH testing.
-    runs-on: ubuntu-latest
-    environment: cloud-VMs
-    steps:
-      - name: Approved for cloud VM testing
-        run: echo "approved"
-
   test:
-    needs: approve
-    # No environment here — SSH keys come from repository secrets (see header).
     # One concurrent SSH test run per physical host across all workflow runs.
+    # Concurrency is evaluated when the job queues (including while waiting for
+    # environment approval) — a known GitHub Actions limitation.
     concurrency:
       group: cloud-test-host-${{ matrix.hostname }}
       cancel-in-progress: false
     runs-on: ubuntu-latest
+    environment: cloud-VMs
     strategy:
       matrix:
         include:

--- a/.github/workflows/cloud_provider.yml
+++ b/.github/workflows/cloud_provider.yml
@@ -40,13 +40,23 @@ permissions:
 # Coverage from all environments (no CSP, AWS, Azure, GCP) is uploaded to Codecov
 
 jobs:
+  approve:
+    # Single approval unlocks all matrix hosts for this workflow run.
+    # Concurrency must not be acquired here; it would block other runs
+    # while waiting for environment approval instead of during SSH testing.
+    runs-on: ubuntu-latest
+    environment: cloud-VMs
+    steps:
+      - name: Approved for cloud VM testing
+        run: echo "approved"
+
   test:
+    needs: approve
     # One concurrent SSH test run per physical host across all workflow runs.
     concurrency:
       group: cloud-test-host-${{ matrix.hostname }}
       cancel-in-progress: false
     runs-on: ubuntu-latest
-    environment: cloud-VMs
     strategy:
       matrix:
         include:

--- a/.github/workflows/cloud_provider.yml
+++ b/.github/workflows/cloud_provider.yml
@@ -1,10 +1,16 @@
 name: Cloud Provider Tests
 
-on: 
+on:
   pull_request:
     branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      hostname:
+        description: 'Clear lock on this host only (empty = all matrix hosts)'
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -38,15 +44,18 @@ permissions:
 # Go: Runs integration tests with coverage reporting (go coverage format)
 # Python: Uses automated validation framework with coverage reporting (XML format)
 # Coverage from all environments (no CSP, AWS, Azure, GCP) is uploaded to Codecov
+#
+# Per-host concurrency: each matrix leg acquires a remote lock on its VM after SSH
+# setup (post environment approval). Lock path on each host:
+#   /tmp/s2iam-cloud-test.lock.d/   (atomic mkdir; info file inside for debugging)
+# Release runs in an always() cleanup step. Stale locks (runner kill, network drop)
+# can be cleared via workflow_dispatch -> clear-stale-locks job.
 
 jobs:
   test:
+    if: github.event_name != 'workflow_dispatch'
     # Single test job with matrix over cloud VM hosts. SSH keys remain environment secrets.
-    # Per-matrix concurrency: one group for all matrix legs on this ref (not per host).
-    # Evaluated when jobs queue, including while waiting for environment approval.
-    concurrency:
-      group: cloud-provider-test-${{ github.ref }}
-      cancel-in-progress: false
+    # Per-host serialization uses remote locks on each VM (see header comment).
     runs-on: ubuntu-latest
     environment: cloud-VMs
     strategy:
@@ -90,6 +99,7 @@ jobs:
       EXTRA_ENV: ${{ matrix.env_vars }}
       SSH_OPTS: "-i ~/.ssh/key -o StrictHostKeyChecking=no -o ConnectTimeout=10"
       HOST: ${{ matrix.username }}@${{ matrix.hostname }}
+      LOCK_DIR: /tmp/s2iam-cloud-test.lock.d
 
     steps:
     - name: Checkout repository
@@ -102,6 +112,34 @@ jobs:
         chmod 600 ~/.ssh/key
         ssh-keyscan -H ${{ matrix.hostname }} >> ~/.ssh/known_hosts
         ssh ${{ env.SSH_OPTS }} ${{ env.HOST }} "echo 'SSH connection successful'"
+
+    - name: Acquire remote lock
+      id: lock
+      run: |
+        set -euo pipefail
+        max_wait_seconds=7200
+        interval=30
+        elapsed=0
+        while ! ssh ${{ env.SSH_OPTS }} ${{ env.HOST }} "mkdir '${{ env.LOCK_DIR }}' 2>/dev/null"; do
+          echo "Lock held on ${{ matrix.hostname }}; waiting ${interval}s..."
+          ssh ${{ env.SSH_OPTS }} ${{ env.HOST }} "cat '${{ env.LOCK_DIR }}/info' 2>/dev/null || echo '(no lock info)'" || true
+          sleep "${interval}"
+          elapsed=$((elapsed + interval))
+          if [ "${elapsed}" -ge "${max_wait_seconds}" ]; then
+            echo "Timed out waiting for lock on ${{ matrix.hostname }} after ${max_wait_seconds}s"
+            exit 1
+          fi
+        done
+        ssh ${{ env.SSH_OPTS }} ${{ env.HOST }} "printf '%s\n' \
+          'run_id=${{ github.run_id }}' \
+          'run_attempt=${{ github.run_attempt }}' \
+          'ref=${{ github.ref }}' \
+          'matrix=${{ matrix.name }}' \
+          'hostname=${{ matrix.hostname }}' \
+          \"acquired_utc=\$(date -u +%Y-%m-%dT%H:%M:%SZ)\" \
+          > '${{ env.LOCK_DIR }}/info'"
+        echo "acquired=true" >> "${GITHUB_OUTPUT}"
+        echo "Lock acquired on ${{ matrix.hostname }}"
 
     - name: Run remote tests via Make (copy, run, download, cleanup)
       env:
@@ -157,7 +195,87 @@ jobs:
         set -e
         make ssh-cleanup-remote
 
+    - name: Release remote lock
+      if: always() && steps.lock.outputs.acquired == 'true'
+      run: |
+        set -euo pipefail
+        ssh ${{ env.SSH_OPTS }} ${{ env.HOST }} "rm -rf '${{ env.LOCK_DIR }}'"
+        echo "Lock released on ${{ matrix.hostname }}"
+
     - name: Cleanup SSH key
       if: always()
+      run: |
+        rm -f ~/.ssh/key
+
+  clear-stale-locks:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment: cloud-VMs
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: aws-positive
+            username: ubuntu
+            hostname: ec2-18-206-180-126.compute-1.amazonaws.com
+            secret: AWS_POSITIVE_KEY
+          - name: aws-negative
+            username: ubuntu
+            hostname: ec2-35-173-183-101.compute-1.amazonaws.com
+            secret: AWS_POSITIVE_KEY
+          - name: azure-positive
+            username: azureuser
+            hostname: 52.186.98.155
+            secret: AZURE_POSITIVE_KEY
+          - name: azure-negative
+            username: azureuser
+            hostname: 74.235.105.73
+            secret: AZURE_NEGATIVE_KEY
+          - name: gcp-positive
+            username: dsharnoff
+            hostname: 34.145.164.5
+            secret: GCP_POSITIVE_KEY
+          - name: gcp-negative
+            username: dsharnoff
+            hostname: 34.21.55.72
+            secret: GCP_POSITIVE_KEY
+
+    env:
+      SSH_KEY_SECRET: ${{ matrix.secret }}
+      SSH_OPTS: "-i ~/.ssh/key -o StrictHostKeyChecking=no -o ConnectTimeout=10"
+      HOST: ${{ matrix.username }}@${{ matrix.hostname }}
+      LOCK_DIR: /tmp/s2iam-cloud-test.lock.d
+
+    steps:
+    - name: Skip host not selected
+      if: github.event.inputs.hostname != '' && github.event.inputs.hostname != matrix.hostname
+      run: echo "Skipping ${{ matrix.hostname }} (not selected)" && exit 0
+
+    - name: Setup SSH key
+      if: github.event.inputs.hostname == '' || github.event.inputs.hostname == matrix.hostname
+      run: |
+        mkdir -p ~/.ssh
+        echo "${{ secrets[env.SSH_KEY_SECRET] }}" > ~/.ssh/key
+        chmod 600 ~/.ssh/key
+        ssh-keyscan -H ${{ matrix.hostname }} >> ~/.ssh/known_hosts
+        ssh ${{ env.SSH_OPTS }} ${{ env.HOST }} "echo 'SSH connection successful'"
+
+    - name: Clear stale lock
+      if: github.event.inputs.hostname == '' || github.event.inputs.hostname == matrix.hostname
+      run: |
+        set -euo pipefail
+        ssh ${{ env.SSH_OPTS }} ${{ env.HOST }} "
+          if [ -d '${{ env.LOCK_DIR }}' ]; then
+            echo 'Stale lock on ${{ matrix.hostname }}:'
+            cat '${{ env.LOCK_DIR }}/info' 2>/dev/null || echo '(no lock info)'
+            rm -rf '${{ env.LOCK_DIR }}'
+            echo 'Lock cleared.'
+          else
+            echo 'No lock present on ${{ matrix.hostname }}.'
+          fi
+        "
+
+    - name: Cleanup SSH key
+      if: always() && (github.event.inputs.hostname == '' || github.event.inputs.hostname == matrix.hostname)
       run: |
         rm -f ~/.ssh/key

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ help:
 	@echo "  ENV_VARS=\"VAR1=val1 VAR2=val2\"           Environment variables for remote tests"
 	@echo ""
 	@echo "Per-host Cloud Test Lock (ssh-acquire/release/clear-lock):"
-	@echo "  LOCK_DIR=/tmp/s2iam-cloud-test.lock.d     Lock directory on HOST (default)"
+	@echo "  Lock path on HOST: /tmp/s2iam-cloud-test.lock.d (fixed)"
 	@echo "  LOCK_RUN_ID LOCK_RUN_ATTEMPT LOCK_REF     Optional metadata for lock info file"
 	@echo "  LOCK_MATRIX LOCK_HOSTNAME                 Optional metadata for lock info file"
 	@echo ""
@@ -319,7 +319,8 @@ clean:
 # Use := to evaluate once at parse time rather than each time it's used
 REMOTE_BASE_DIR ?= tests
 SSH_OPTS ?= -o StrictHostKeyChecking=no -o ConnectTimeout=10
-LOCK_DIR ?= /tmp/s2iam-cloud-test.lock.d
+# Fixed per-host cloud test lock path (not overridable).
+override S2IAM_CLOUD_TEST_LOCK_DIR := /tmp/s2iam-cloud-test.lock.d
 LOCK_MAX_WAIT_SECONDS ?= 7200
 LOCK_INTERVAL ?= 30
 # Hostname portion of HOST (user@host -> host); localhost skips SSH for local lock testing.
@@ -380,32 +381,32 @@ ssh-cleanup-remote: check-host
 	@echo "Cleaning up remote directory on $(HOST)..."
 	ssh $(SSH_OPTS) $(HOST) "rm -rf $(REMOTE_BASE_DIR)/$(UNIQUE_DIR)"
 
-# Per-host cloud test locks (atomic mkdir on LOCK_DIR; info file for debugging).
+# Per-host cloud test locks (atomic mkdir on S2IAM_CLOUD_TEST_LOCK_DIR; info file for debugging).
 # Runner-side targets: lock is acquired before ssh-copy-to-remote deploys this Makefile.
 # HOST=localhost (or 127.0.0.1) runs lock commands locally without SSH.
 ssh-acquire-lock: check-host
-	@echo "Acquiring lock on $(HOST) at $(LOCK_DIR)..."
+	@echo "Acquiring lock on $(HOST) at $(S2IAM_CLOUD_TEST_LOCK_DIR)..."
 	@bash -eu -o pipefail -c '_run(){ case "$(HOST_SHORT)" in localhost|127.0.0.1|::1) bash -c "$$1";;*) ssh $(SSH_OPTS) $(HOST) "$$1";;esac;}; \
 	max_wait=$(LOCK_MAX_WAIT_SECONDS); interval=$(LOCK_INTERVAL); elapsed=0; \
 	while true; do \
-	  if _run "mkdir '"'"'$(LOCK_DIR)'"'"' 2>/dev/null"; then break; fi; \
-	  if _run "[ -d '"'"'$(LOCK_DIR)'"'"' ]"; then \
+	  if _run "mkdir '"'"'$(S2IAM_CLOUD_TEST_LOCK_DIR)'"'"' 2>/dev/null"; then break; fi; \
+	  if _run "[ -d '"'"'$(S2IAM_CLOUD_TEST_LOCK_DIR)'"'"' ]"; then \
 	    echo "Lock held on $(HOST); waiting $$interval s..."; \
-	    _run "cat '"'"'$(LOCK_DIR)/info'"'"' 2>/dev/null || echo '"'"'(no lock info)'"'"'"; \
+	    _run "cat '"'"'$(S2IAM_CLOUD_TEST_LOCK_DIR)/info'"'"' 2>/dev/null || echo '"'"'(no lock info)'"'"'"; \
 	    sleep "$$interval"; elapsed=$$((elapsed + interval)); \
 	    if [ "$$elapsed" -ge "$$max_wait" ]; then echo "Timed out waiting for lock on $(HOST) after $$max_wait s"; exit 1; fi; \
 	  else \
 	    rc=$$?; \
 	    if [ $$rc -eq 1 ]; then \
-	      echo "Failed to acquire lock on $(HOST): mkdir failed and $(LOCK_DIR) is absent (not lock contention)"; \
+	      echo "Failed to acquire lock on $(HOST): mkdir failed and $(S2IAM_CLOUD_TEST_LOCK_DIR) is absent (not lock contention)"; \
 	    else \
 	      echo "Failed to check lock on $(HOST) (exit $$rc)"; \
 	    fi; \
 	    exit 1; \
 	  fi; \
 	done; \
-	if ! _run "printf '"'"'%s\n'"'"' '"'"'run_id=$(LOCK_RUN_ID)'"'"' '"'"'run_attempt=$(LOCK_RUN_ATTEMPT)'"'"' '"'"'ref=$(LOCK_REF)'"'"' '"'"'matrix=$(LOCK_MATRIX)'"'"' '"'"'hostname=$(LOCK_HOSTNAME)'"'"' \"acquired_utc=$$(date -u +%Y-%m-%dT%H:%M:%SZ)\" > '"'"'$(LOCK_DIR)/info'"'"'"; then \
-	  if _run "rm -rf '"'"'$(LOCK_DIR)'"'"'"; then \
+	if ! _run "printf '"'"'%s\n'"'"' '"'"'run_id=$(LOCK_RUN_ID)'"'"' '"'"'run_attempt=$(LOCK_RUN_ATTEMPT)'"'"' '"'"'ref=$(LOCK_REF)'"'"' '"'"'matrix=$(LOCK_MATRIX)'"'"' '"'"'hostname=$(LOCK_HOSTNAME)'"'"' \"acquired_utc=$$(date -u +%Y-%m-%dT%H:%M:%SZ)\" > '"'"'$(S2IAM_CLOUD_TEST_LOCK_DIR)/info'"'"'"; then \
+	  if _run "rm -rf '"'"'$(S2IAM_CLOUD_TEST_LOCK_DIR)'"'"'"; then \
 	    echo "Failed to write lock info on $(HOST); lock directory removed"; \
 	  else \
 	    rm_rc=$$?; \
@@ -417,15 +418,15 @@ ssh-acquire-lock: check-host
 
 ssh-release-lock: check-host
 	@echo "Releasing lock on $(HOST)..."
-	@bash -c '_run(){ case "$(HOST_SHORT)" in localhost|127.0.0.1|::1) bash -c "$$1";;*) ssh $(SSH_OPTS) $(HOST) "$$1";;esac;}; _run "rm -rf '"'"'$(LOCK_DIR)'"'"'"'
+	@bash -c '_run(){ case "$(HOST_SHORT)" in localhost|127.0.0.1|::1) bash -c "$$1";;*) ssh $(SSH_OPTS) $(HOST) "$$1";;esac;}; _run "rm -rf '"'"'$(S2IAM_CLOUD_TEST_LOCK_DIR)'"'"'"'
 	@echo "Lock released on $(HOST)"
 
 ssh-clear-lock: check-host
 	@bash -eu -o pipefail -c '_run(){ case "$(HOST_SHORT)" in localhost|127.0.0.1|::1) bash -c "$$1";;*) ssh $(SSH_OPTS) $(HOST) "$$1";;esac;}; \
-	if _run "[ -d '"'"'$(LOCK_DIR)'"'"' ]"; then \
+	if _run "[ -d '"'"'$(S2IAM_CLOUD_TEST_LOCK_DIR)'"'"' ]"; then \
 	  echo "Stale lock on $(HOST):"; \
-	  _run "cat '"'"'$(LOCK_DIR)/info'"'"' 2>/dev/null || echo '"'"'(no lock info)'"'"'"; \
-	  _run "rm -rf '"'"'$(LOCK_DIR)'"'"'"; \
+	  _run "cat '"'"'$(S2IAM_CLOUD_TEST_LOCK_DIR)/info'"'"' 2>/dev/null || echo '"'"'(no lock info)'"'"'"; \
+	  _run "rm -rf '"'"'$(S2IAM_CLOUD_TEST_LOCK_DIR)'"'"'"; \
 	  echo "Lock cleared."; \
 	else \
 	  rc=$$?; \

--- a/Makefile
+++ b/Makefile
@@ -387,11 +387,16 @@ ssh-acquire-lock: check-host
 	@echo "Acquiring lock on $(HOST) at $(LOCK_DIR)..."
 	@bash -eu -o pipefail -c '_run(){ case "$(HOST_SHORT)" in localhost|127.0.0.1|::1) bash -c "$$1";;*) ssh $(SSH_OPTS) $(HOST) "$$1";;esac;}; \
 	max_wait=$(LOCK_MAX_WAIT_SECONDS); interval=$(LOCK_INTERVAL); elapsed=0; \
-	while ! _run "mkdir '"'"'$(LOCK_DIR)'"'"' 2>/dev/null"; do \
-	  echo "Lock held on $(HOST); waiting $$interval s..."; \
-	  _run "cat '"'"'$(LOCK_DIR)/info'"'"' 2>/dev/null || echo '"'"'(no lock info)'"'"'" || true; \
-	  sleep "$$interval"; elapsed=$$((elapsed + interval)); \
-	  if [ "$$elapsed" -ge "$$max_wait" ]; then echo "Timed out waiting for lock on $(HOST) after $$max_wait s"; exit 1; fi; \
+	while true; do \
+	  if _run "mkdir '"'"'$(LOCK_DIR)'"'"' 2>/dev/null"; then break; fi; \
+	  if _run "[ -d '"'"'$(LOCK_DIR)'"'"' ]"; then \
+	    echo "Lock held on $(HOST); waiting $$interval s..."; \
+	    _run "cat '"'"'$(LOCK_DIR)/info'"'"' 2>/dev/null || echo '"'"'(no lock info)'"'"'"; \
+	    sleep "$$interval"; elapsed=$$((elapsed + interval)); \
+	    if [ "$$elapsed" -ge "$$max_wait" ]; then echo "Timed out waiting for lock on $(HOST) after $$max_wait s"; exit 1; fi; \
+	  else \
+	    rc=$$?; echo "Failed to acquire lock on $(HOST): mkdir failed and $(LOCK_DIR) is absent (exit $$rc; not lock contention)"; exit 1; \
+	  fi; \
 	done; \
 	_run "printf '"'"'%s\n'"'"' '"'"'run_id=$(LOCK_RUN_ID)'"'"' '"'"'run_attempt=$(LOCK_RUN_ATTEMPT)'"'"' '"'"'ref=$(LOCK_REF)'"'"' '"'"'matrix=$(LOCK_MATRIX)'"'"' '"'"'hostname=$(LOCK_HOSTNAME)'"'"' \"acquired_utc=$$(date -u +%Y-%m-%dT%H:%M:%SZ)\" > '"'"'$(LOCK_DIR)/info'"'"'"; \
 	echo "Lock acquired on $(HOST)"'
@@ -409,7 +414,9 @@ ssh-clear-lock: check-host
 	  _run "rm -rf '"'"'$(LOCK_DIR)'"'"'"; \
 	  echo "Lock cleared."; \
 	else \
-	  echo "No lock present on $(LOCK_HOSTNAME)."; \
+	  rc=$$?; \
+	  if [ $$rc -eq 1 ]; then echo "No lock present on $(LOCK_HOSTNAME)."; \
+	  else echo "Failed to check lock on $(LOCK_HOSTNAME) (exit $$rc)"; exit 1; fi; \
 	fi'
 
 

--- a/Makefile
+++ b/Makefile
@@ -404,7 +404,11 @@ ssh-acquire-lock: check-host
 	    exit 1; \
 	  fi; \
 	done; \
-	_run "printf '"'"'%s\n'"'"' '"'"'run_id=$(LOCK_RUN_ID)'"'"' '"'"'run_attempt=$(LOCK_RUN_ATTEMPT)'"'"' '"'"'ref=$(LOCK_REF)'"'"' '"'"'matrix=$(LOCK_MATRIX)'"'"' '"'"'hostname=$(LOCK_HOSTNAME)'"'"' \"acquired_utc=$$(date -u +%Y-%m-%dT%H:%M:%SZ)\" > '"'"'$(LOCK_DIR)/info'"'"'"; \
+	if ! _run "printf '"'"'%s\n'"'"' '"'"'run_id=$(LOCK_RUN_ID)'"'"' '"'"'run_attempt=$(LOCK_RUN_ATTEMPT)'"'"' '"'"'ref=$(LOCK_REF)'"'"' '"'"'matrix=$(LOCK_MATRIX)'"'"' '"'"'hostname=$(LOCK_HOSTNAME)'"'"' \"acquired_utc=$$(date -u +%Y-%m-%dT%H:%M:%SZ)\" > '"'"'$(LOCK_DIR)/info'"'"'"; then \
+	  _run "rm -rf '"'"'$(LOCK_DIR)'"'"'" 2>/dev/null || true; \
+	  echo "Failed to write lock info on $(HOST); lock directory removed"; \
+	  exit 1; \
+	fi; \
 	echo "Lock acquired on $(HOST)"'
 
 ssh-release-lock: check-host

--- a/Makefile
+++ b/Makefile
@@ -405,8 +405,12 @@ ssh-acquire-lock: check-host
 	  fi; \
 	done; \
 	if ! _run "printf '"'"'%s\n'"'"' '"'"'run_id=$(LOCK_RUN_ID)'"'"' '"'"'run_attempt=$(LOCK_RUN_ATTEMPT)'"'"' '"'"'ref=$(LOCK_REF)'"'"' '"'"'matrix=$(LOCK_MATRIX)'"'"' '"'"'hostname=$(LOCK_HOSTNAME)'"'"' \"acquired_utc=$$(date -u +%Y-%m-%dT%H:%M:%SZ)\" > '"'"'$(LOCK_DIR)/info'"'"'"; then \
-	  _run "rm -rf '"'"'$(LOCK_DIR)'"'"'" 2>/dev/null || true; \
-	  echo "Failed to write lock info on $(HOST); lock directory removed"; \
+	  if _run "rm -rf '"'"'$(LOCK_DIR)'"'"'"; then \
+	    echo "Failed to write lock info on $(HOST); lock directory removed"; \
+	  else \
+	    rm_rc=$$?; \
+	    echo "Failed to write lock info on $(HOST); could not remove lock directory (exit $$rm_rc)"; \
+	  fi; \
 	  exit 1; \
 	fi; \
 	echo "Lock acquired on $(HOST)"'

--- a/Makefile
+++ b/Makefile
@@ -395,7 +395,13 @@ ssh-acquire-lock: check-host
 	    sleep "$$interval"; elapsed=$$((elapsed + interval)); \
 	    if [ "$$elapsed" -ge "$$max_wait" ]; then echo "Timed out waiting for lock on $(HOST) after $$max_wait s"; exit 1; fi; \
 	  else \
-	    rc=$$?; echo "Failed to acquire lock on $(HOST): mkdir failed and $(LOCK_DIR) is absent (exit $$rc; not lock contention)"; exit 1; \
+	    rc=$$?; \
+	    if [ $$rc -eq 1 ]; then \
+	      echo "Failed to acquire lock on $(HOST): mkdir failed and $(LOCK_DIR) is absent (not lock contention)"; \
+	    else \
+	      echo "Failed to check lock on $(HOST) (exit $$rc)"; \
+	    fi; \
+	    exit 1; \
 	  fi; \
 	done; \
 	_run "printf '"'"'%s\n'"'"' '"'"'run_id=$(LOCK_RUN_ID)'"'"' '"'"'run_attempt=$(LOCK_RUN_ATTEMPT)'"'"' '"'"'ref=$(LOCK_REF)'"'"' '"'"'matrix=$(LOCK_MATRIX)'"'"' '"'"'hostname=$(LOCK_HOSTNAME)'"'"' \"acquired_utc=$$(date -u +%Y-%m-%dT%H:%M:%SZ)\" > '"'"'$(LOCK_DIR)/info'"'"'"; \
@@ -409,14 +415,14 @@ ssh-release-lock: check-host
 ssh-clear-lock: check-host
 	@bash -eu -o pipefail -c '_run(){ case "$(HOST_SHORT)" in localhost|127.0.0.1|::1) bash -c "$$1";;*) ssh $(SSH_OPTS) $(HOST) "$$1";;esac;}; \
 	if _run "[ -d '"'"'$(LOCK_DIR)'"'"' ]"; then \
-	  echo "Stale lock on $(LOCK_HOSTNAME):"; \
+	  echo "Stale lock on $(HOST):"; \
 	  _run "cat '"'"'$(LOCK_DIR)/info'"'"' 2>/dev/null || echo '"'"'(no lock info)'"'"'"; \
 	  _run "rm -rf '"'"'$(LOCK_DIR)'"'"'"; \
 	  echo "Lock cleared."; \
 	else \
 	  rc=$$?; \
-	  if [ $$rc -eq 1 ]; then echo "No lock present on $(LOCK_HOSTNAME)."; \
-	  else echo "Failed to check lock on $(LOCK_HOSTNAME) (exit $$rc)"; exit 1; fi; \
+	  if [ $$rc -eq 1 ]; then echo "No lock present on $(HOST)."; \
+	  else echo "Failed to check lock on $(HOST) (exit $$rc)"; exit 1; fi; \
 	fi'
 
 

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ help:
 	@echo "    make ssh-acquire-lock                   Acquire per-host cloud test lock on HOST"
 	@echo "    make ssh-release-lock                   Release per-host cloud test lock on HOST"
 	@echo "    make ssh-clear-lock                     Clear stale per-host cloud test lock on HOST"
+	@echo "      Local test: HOST=localhost make ssh-acquire-lock (no SSH; LOCK_* optional)"
 	@echo ""
 	@echo "Development Setup:"
 	@echo "  make dev-setup-ubuntu                     Full dev setup Ubuntu/Debian (Go + Python + Java)"
@@ -77,6 +78,11 @@ help:
 	@echo "Required for Remote Testing:"
 	@echo "  HOST=user@hostname                        Target host for remote testing"
 	@echo "  ENV_VARS=\"VAR1=val1 VAR2=val2\"           Environment variables for remote tests"
+	@echo ""
+	@echo "Per-host Cloud Test Lock (ssh-acquire/release/clear-lock):"
+	@echo "  LOCK_DIR=/tmp/s2iam-cloud-test.lock.d     Lock directory on HOST (default)"
+	@echo "  LOCK_RUN_ID LOCK_RUN_ATTEMPT LOCK_REF     Optional metadata for lock info file"
+	@echo "  LOCK_MATRIX LOCK_HOSTNAME                 Optional metadata for lock info file"
 	@echo ""
 	@echo "For Cloud Provider Specific Targets (set externally):"
 	@echo "  AWS_POSITIVE_HOST=user@hostname           AWS positive test host"
@@ -316,6 +322,8 @@ SSH_OPTS ?= -o StrictHostKeyChecking=no -o ConnectTimeout=10
 LOCK_DIR ?= /tmp/s2iam-cloud-test.lock.d
 LOCK_MAX_WAIT_SECONDS ?= 7200
 LOCK_INTERVAL ?= 30
+# Hostname portion of HOST (user@host -> host); localhost skips SSH for local lock testing.
+HOST_SHORT := $(lastword $(subst @, ,$(HOST)))
 
 # SSH operations (low-level operations for copying code and running tests)
 # CI target - copy code to remote host
@@ -374,48 +382,34 @@ ssh-cleanup-remote: check-host
 
 # Per-host cloud test locks (atomic mkdir on LOCK_DIR; info file for debugging).
 # Runner-side targets: lock is acquired before ssh-copy-to-remote deploys this Makefile.
+# HOST=localhost (or 127.0.0.1) runs lock commands locally without SSH.
 ssh-acquire-lock: check-host
 	@echo "Acquiring lock on $(HOST) at $(LOCK_DIR)..."
-	@set -euo pipefail; \
-	max_wait=$(LOCK_MAX_WAIT_SECONDS); \
-	interval=$(LOCK_INTERVAL); \
-	elapsed=0; \
-	while ! ssh $(SSH_OPTS) $(HOST) "mkdir '$(LOCK_DIR)' 2>/dev/null"; do \
-		echo "Lock held on $(HOST); waiting $${interval}s..."; \
-		ssh $(SSH_OPTS) $(HOST) "cat '$(LOCK_DIR)/info' 2>/dev/null || echo '(no lock info)'" || true; \
-		sleep "$${interval}"; \
-		elapsed=$$((elapsed + interval)); \
-		if [ "$${elapsed}" -ge "$${max_wait}" ]; then \
-			echo "Timed out waiting for lock on $(HOST) after $${max_wait}s"; \
-			exit 1; \
-		fi; \
+	@bash -eu -o pipefail -c '_run(){ case "$(HOST_SHORT)" in localhost|127.0.0.1|::1) bash -c "$$1";;*) ssh $(SSH_OPTS) $(HOST) "$$1";;esac;}; \
+	max_wait=$(LOCK_MAX_WAIT_SECONDS); interval=$(LOCK_INTERVAL); elapsed=0; \
+	while ! _run "mkdir '"'"'$(LOCK_DIR)'"'"' 2>/dev/null"; do \
+	  echo "Lock held on $(HOST); waiting $$interval s..."; \
+	  _run "cat '"'"'$(LOCK_DIR)/info'"'"' 2>/dev/null || echo '"'"'(no lock info)'"'"'" || true; \
+	  sleep "$$interval"; elapsed=$$((elapsed + interval)); \
+	  if [ "$$elapsed" -ge "$$max_wait" ]; then echo "Timed out waiting for lock on $(HOST) after $$max_wait s"; exit 1; fi; \
 	done; \
-	ssh $(SSH_OPTS) $(HOST) "printf '%s\n' \
-		'run_id=$(LOCK_RUN_ID)' \
-		'run_attempt=$(LOCK_RUN_ATTEMPT)' \
-		'ref=$(LOCK_REF)' \
-		'matrix=$(LOCK_MATRIX)' \
-		'hostname=$(LOCK_HOSTNAME)' \
-		\"acquired_utc=\$$(date -u +%Y-%m-%dT%H:%M:%SZ)\" \
-		> '$(LOCK_DIR)/info'"; \
-	echo "Lock acquired on $(HOST)"
+	_run "printf '"'"'%s\n'"'"' '"'"'run_id=$(LOCK_RUN_ID)'"'"' '"'"'run_attempt=$(LOCK_RUN_ATTEMPT)'"'"' '"'"'ref=$(LOCK_REF)'"'"' '"'"'matrix=$(LOCK_MATRIX)'"'"' '"'"'hostname=$(LOCK_HOSTNAME)'"'"' \"acquired_utc=$$(date -u +%Y-%m-%dT%H:%M:%SZ)\" > '"'"'$(LOCK_DIR)/info'"'"'"; \
+	echo "Lock acquired on $(HOST)"'
 
 ssh-release-lock: check-host
 	@echo "Releasing lock on $(HOST)..."
-	ssh $(SSH_OPTS) $(HOST) "rm -rf '$(LOCK_DIR)'"
+	@bash -c '_run(){ case "$(HOST_SHORT)" in localhost|127.0.0.1|::1) bash -c "$$1";;*) ssh $(SSH_OPTS) $(HOST) "$$1";;esac;}; _run "rm -rf '"'"'$(LOCK_DIR)'"'"'"'
 	@echo "Lock released on $(HOST)"
 
 ssh-clear-lock: check-host
-	@set -euo pipefail; \
-	ssh $(SSH_OPTS) $(HOST) " \
-		if [ -d '$(LOCK_DIR)' ]; then \
-			echo 'Stale lock on $(LOCK_HOSTNAME):'; \
-			cat '$(LOCK_DIR)/info' 2>/dev/null || echo '(no lock info)'; \
-			rm -rf '$(LOCK_DIR)'; \
-			echo 'Lock cleared.'; \
-		else \
-			echo 'No lock present on $(LOCK_HOSTNAME).'; \
-		fi \
-	"
+	@bash -eu -o pipefail -c '_run(){ case "$(HOST_SHORT)" in localhost|127.0.0.1|::1) bash -c "$$1";;*) ssh $(SSH_OPTS) $(HOST) "$$1";;esac;}; \
+	if _run "[ -d '"'"'$(LOCK_DIR)'"'"' ]"; then \
+	  echo "Stale lock on $(LOCK_HOSTNAME):"; \
+	  _run "cat '"'"'$(LOCK_DIR)/info'"'"' 2>/dev/null || echo '"'"'(no lock info)'"'"'"; \
+	  _run "rm -rf '"'"'$(LOCK_DIR)'"'"'"; \
+	  echo "Lock cleared."; \
+	else \
+	  echo "No lock present on $(LOCK_HOSTNAME)."; \
+	fi'
 
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ export UNIQUE_DIR
  format format-go format-python format-java \
  ssh-copy-to-remote ssh-run-remote-tests \
  ssh-download-coverage ssh-download-coverage-go ssh-download-coverage-python ssh-download-coverage-java \
- ssh-cleanup-remote
+ ssh-cleanup-remote ssh-acquire-lock ssh-release-lock ssh-clear-lock
 
 # Default target
 help:
@@ -49,6 +49,9 @@ help:
 	@echo "    make ssh-download-coverage-go           Download Go coverage only"
 	@echo "    make ssh-download-coverage-python       Download Python coverage only"
 	@echo "    make ssh-cleanup-remote                 Clean up remote directory on HOST"
+	@echo "    make ssh-acquire-lock                   Acquire per-host cloud test lock on HOST"
+	@echo "    make ssh-release-lock                   Release per-host cloud test lock on HOST"
+	@echo "    make ssh-clear-lock                     Clear stale per-host cloud test lock on HOST"
 	@echo ""
 	@echo "Development Setup:"
 	@echo "  make dev-setup-ubuntu                     Full dev setup Ubuntu/Debian (Go + Python + Java)"
@@ -310,6 +313,9 @@ clean:
 # Use := to evaluate once at parse time rather than each time it's used
 REMOTE_BASE_DIR ?= tests
 SSH_OPTS ?= -o StrictHostKeyChecking=no -o ConnectTimeout=10
+LOCK_DIR ?= /tmp/s2iam-cloud-test.lock.d
+LOCK_MAX_WAIT_SECONDS ?= 7200
+LOCK_INTERVAL ?= 30
 
 # SSH operations (low-level operations for copying code and running tests)
 # CI target - copy code to remote host
@@ -365,5 +371,51 @@ ssh-download-coverage-java: check-host
 ssh-cleanup-remote: check-host
 	@echo "Cleaning up remote directory on $(HOST)..."
 	ssh $(SSH_OPTS) $(HOST) "rm -rf $(REMOTE_BASE_DIR)/$(UNIQUE_DIR)"
+
+# Per-host cloud test locks (atomic mkdir on LOCK_DIR; info file for debugging).
+# Runner-side targets: lock is acquired before ssh-copy-to-remote deploys this Makefile.
+ssh-acquire-lock: check-host
+	@echo "Acquiring lock on $(HOST) at $(LOCK_DIR)..."
+	@set -euo pipefail; \
+	max_wait=$(LOCK_MAX_WAIT_SECONDS); \
+	interval=$(LOCK_INTERVAL); \
+	elapsed=0; \
+	while ! ssh $(SSH_OPTS) $(HOST) "mkdir '$(LOCK_DIR)' 2>/dev/null"; do \
+		echo "Lock held on $(HOST); waiting $${interval}s..."; \
+		ssh $(SSH_OPTS) $(HOST) "cat '$(LOCK_DIR)/info' 2>/dev/null || echo '(no lock info)'" || true; \
+		sleep "$${interval}"; \
+		elapsed=$$((elapsed + interval)); \
+		if [ "$${elapsed}" -ge "$${max_wait}" ]; then \
+			echo "Timed out waiting for lock on $(HOST) after $${max_wait}s"; \
+			exit 1; \
+		fi; \
+	done; \
+	ssh $(SSH_OPTS) $(HOST) "printf '%s\n' \
+		'run_id=$(LOCK_RUN_ID)' \
+		'run_attempt=$(LOCK_RUN_ATTEMPT)' \
+		'ref=$(LOCK_REF)' \
+		'matrix=$(LOCK_MATRIX)' \
+		'hostname=$(LOCK_HOSTNAME)' \
+		\"acquired_utc=\$$(date -u +%Y-%m-%dT%H:%M:%SZ)\" \
+		> '$(LOCK_DIR)/info'"; \
+	echo "Lock acquired on $(HOST)"
+
+ssh-release-lock: check-host
+	@echo "Releasing lock on $(HOST)..."
+	ssh $(SSH_OPTS) $(HOST) "rm -rf '$(LOCK_DIR)'"
+	@echo "Lock released on $(HOST)"
+
+ssh-clear-lock: check-host
+	@set -euo pipefail; \
+	ssh $(SSH_OPTS) $(HOST) " \
+		if [ -d '$(LOCK_DIR)' ]; then \
+			echo 'Stale lock on $(LOCK_HOSTNAME):'; \
+			cat '$(LOCK_DIR)/info' 2>/dev/null || echo '(no lock info)'; \
+			rm -rf '$(LOCK_DIR)'; \
+			echo 'Lock cleared.'; \
+		else \
+			echo 'No lock present on $(LOCK_HOSTNAME).'; \
+		fi \
+	"
 
 


### PR DESCRIPTION
## Summary

Serialize cloud provider tests per VM host using remote locks on each test machine.

- Single `test` job (`environment: cloud-VMs`) with a matrix over cloud VM hosts; SSH keys remain environment secrets.
- Cloud test hosts are defined once in `.github/cloud-test-hosts.json`; both `cloud_provider.yml` and `cloud_clear_stale_locks.yml` load the matrix via a `matrix-prep` job (`jq` + `fromJSON`).
- After SSH setup, each matrix leg acquires an atomic per-host lock at `/tmp/s2iam-cloud-test.lock.d/` (mkdir) via `make ssh-acquire-lock`.
- Lock logic lives in Makefile targets (`ssh-acquire-lock`, `ssh-release-lock`, `ssh-clear-lock`), consistent with existing `ssh-copy-to-remote` / `ssh-cleanup-remote`.
- Lock is released in an `always()` cleanup step (`make ssh-release-lock`).
- Stale locks can be cleared via the **Clear Cloud Test Locks** workflow (`cloud_clear_stale_locks.yml`).

Also bumps `codecov/codecov-action` to v5.5.5 across upload steps.

## Test plan

- [ ] Push/PR triggers cloud tests; matrix legs on different hosts run in parallel
- [ ] Two runs targeting the same host serialize (second waits, then proceeds)
- [ ] Actions → Clear Cloud Test Locks clears lock on selected host (or all)
- [ ] Failed/killed run still releases lock via cleanup step

### Clearing stale locks

Actions → **Clear Cloud Test Locks** → Run workflow. Leave `hostname` empty to clear all VMs, or set it to clear one host.

### Local lock testing

Runner-side lock targets can be exercised locally without SSH:
`HOST=localhost make ssh-acquire-lock` / `ssh-release-lock` / `ssh-clear-lock`.
Optional `LOCK_*` env vars populate the lock info file. Lock path is fixed at `/tmp/s2iam-cloud-test.lock.d`.