### PR TITLE
ci: add PyPI publish workflow with Trusted Publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -34,6 +34,7 @@ jobs:
             exit 1
           fi
           sed -i "s/^__version__ = \".*\"/__version__ = \"${RELEASE_VERSION}\"/" src/s2iam/__init__.py
+          grep -q "__version__ = \"${RELEASE_VERSION}\"" src/s2iam/__init__.py
 
       - name: Build distributions
         working-directory: python

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,66 @@
+name: Publish Python package to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install build dependencies
+        run: python -m pip install --upgrade pip build hatchling
+
+      - name: Set release version from tag
+        working-directory: python
+        run: |
+          set -euo pipefail
+          RELEASE_VERSION="${GITHUB_REF_NAME#v}"
+          if [ -z "${RELEASE_VERSION}" ] || ! echo "${RELEASE_VERSION}" | grep -Eq '^[0-9]+(\.[0-9]+)*(-[A-Za-z0-9.-]+)?$'; then
+            echo "Invalid release tag ${GITHUB_REF_NAME}; expected vMAJOR[.MINOR[.PATCH]][-qualifier]" >&2
+            exit 1
+          fi
+          sed -i "s/^__version__ = \".*\"/__version__ = \"${RELEASE_VERSION}\"/" src/s2iam/__init__.py
+
+      - name: Build distributions
+        working-directory: python
+        run: python -m build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-dist
+          path: python/dist/
+
+  publish:
+    name: Upload release to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: pypi
+      url: https://pypi.org/project/singlestore-auth-iam/
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: dist/
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,7 +7,7 @@ name = "singlestore-auth-iam"
 description = "SingleStore IAM authentication library for cloud providers"
 readme = "README.md"
 requires-python = ">=3.9"
-license = {file = "../LICENSE"}
+license = "MIT"
 authors = [
     {name = "SingleStore Labs"},
 ]
@@ -58,15 +58,11 @@ path = "src/s2iam/__init__.py"
 include = [
     "/src",
     "/tests",
-    "../LICENSE",
 ]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/s2iam"]
 sources = ["src"]
-artifacts = [
-    "../LICENSE",
-]
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
## Summary

Adds a dedicated PyPI release workflow for the Python `singlestore-auth-iam` package (`python/`).

- **Workflow:** `.github/workflows/publish-pypi.yml` — tag-triggered build + publish using PyPI **Trusted Publishing** (GitHub OIDC; no long-lived PyPI API token in repo secrets)
- **Package:** `singlestore-auth-iam` (Hatchling build from `python/pyproject.toml`)
- **Trigger:** push of `v*` tags (same tag convention as #69 Maven releases)

## Pre-merge: PyPI Trusted Publisher setup

On the PyPI project for `singlestore-auth-iam`, add a **Trusted Publisher**:

| Field | Value |
|-------|-------|
| Publisher | GitHub |
| Owner | `singlestore-labs` |
| Repository | `singlestore-auth-iam` |
| Workflow name | `publish-pypi.yml` |
| Environment | `pypi` (recommended) |

No `PYPI_API_TOKEN` secret is required when Trusted Publishing is configured.

Optionally create a GitHub repository **environment** named `pypi` (Settings → Environments) if you want release approval gates or environment-scoped protection rules.

## Post-merge: publishing a release

Versioning is **tag-based**. Leave `python/src/s2iam/__init__.py` at the development version on `main`; do not bump it in the repo for a release.

To publish:

```bash
git tag v0.1.0
git push origin v0.1.0
```

- **Tag format:** `vMAJOR.MINOR.PATCH` (optional `-qualifier`, e.g. `v1.0.0-rc1`)
- The workflow strips the leading `v` and writes the remainder into `__version__` before building
- Pushing the tag runs the `build` job, then the `publish` job uploads to PyPI via OIDC

## Test plan

- [ ] Merge after PyPI Trusted Publisher is configured for this workflow
- [ ] Push a test tag (or use a pre-release tag) and confirm the workflow completes
- [ ] Verify the new version appears on https://pypi.org/project/singlestore-auth-iam/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and packaging metadata only; release publishing depends on correct PyPI Trusted Publisher setup but does not change runtime library code.
> 
> **Overview**
> Adds **automated PyPI releases** for `singlestore-auth-iam` when `v*` tags are pushed, aligned with the existing Maven tag-based release pattern.
> 
> The new **`publish-pypi.yml`** workflow runs a **build** job (Python 3.11, `hatchling`/`build`, validates the tag, rewrites `__version__` in `src/s2iam/__init__.py` from the tag, uploads `python/dist/` as an artifact) and a **publish** job that uses the **`pypi` GitHub environment** and **OIDC** (`id-token: write` + `pypa/gh-action-pypi-publish`)—no long-lived PyPI token in repo secrets.
> 
> **`python/pyproject.toml`** switches the project license to the SPDX **`MIT`** string and drops bundling `../LICENSE` in Hatch **sdist/wheel** includes/artifacts so packaging matches standard PyPI metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fba5c7308b56080a412883e87dafe99b0c9d1e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->