### PR TITLE
ci: split Maven Central publish from java test workflow

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -2,9 +2,9 @@ name: java
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
-    branches: [main]
+    branches: [ main ]
 
 jobs:
   build-test-coverage:
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: "21"
+          java-version: '21'
           cache: maven
 
       - name: Lint / formatting check

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -3,7 +3,6 @@ name: java
 on:
   push:
     branches: [main]
-    tags: ["v*"]
   pull_request:
     branches: [main]
 
@@ -47,40 +46,3 @@ jobs:
           fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-  release:
-    needs: build-test-coverage
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up JDK 21 with Maven Central settings
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: "21"
-          cache: maven
-          server-id: central
-          server-username: SONATYPE_USERNAME
-          server-password: SONATYPE_PASSWORD
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
-
-      - name: Build and publish to Maven Central
-        env:
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USER }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        working-directory: java
-        run: |
-          set -euo pipefail
-          RELEASE_VERSION="${GITHUB_REF_NAME#v}"
-          if [ -z "${RELEASE_VERSION}" ] || ! echo "${RELEASE_VERSION}" | grep -Eq '^[0-9]+(\.[0-9]+)*(-[A-Za-z0-9.-]+)?$'; then
-            echo "Invalid release tag ${GITHUB_REF_NAME}; expected vMAJOR[.MINOR[.PATCH]][-qualifier]" >&2
-            exit 1
-          fi
-          mvn -B versions:set -DnewVersion="${RELEASE_VERSION}" -DgenerateBackupPoms=false
-          mvn -B clean deploy -DskipTests -Prelease

--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -1,0 +1,68 @@
+name: Publish Java package to Maven Central
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+
+      - name: Lint / formatting check
+        run: make lint-java
+
+      - name: Run tests with coverage (mvn verify)
+        working-directory: java
+        run: mvn -q -DskipTests=false verify
+
+  publish:
+    name: Upload release to Maven Central
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21 with Maven Central settings
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+          server-id: central
+          server-username: SONATYPE_USERNAME
+          server-password: SONATYPE_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Build and publish to Maven Central
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USER }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        working-directory: java
+        run: |
+          set -euo pipefail
+          RELEASE_VERSION="${GITHUB_REF_NAME#v}"
+          if [ -z "${RELEASE_VERSION}" ] || ! echo "${RELEASE_VERSION}" | grep -Eq '^[0-9]+(\.[0-9]+)*(-[A-Za-z0-9.-]+)?$'; then
+            echo "Invalid release tag ${GITHUB_REF_NAME}; expected vMAJOR[.MINOR[.PATCH]][-qualifier]" >&2
+            exit 1
+          fi
+          mvn -B versions:set -DnewVersion="${RELEASE_VERSION}" -DgenerateBackupPoms=false
+          mvn -B clean deploy -DskipTests -Prelease


### PR DESCRIPTION
## Summary

Restore `java.yml` to CI-only: lint, test, and Codecov coverage on PRs and pushes to `main` (no tag triggers, no release job).

Add `publish-maven.yml` for Maven Central releases on `v*` tags, mirroring the `publish-pypi.yml` pattern with a build gate before publish.

## Test plan

- [ ] Open a PR and confirm the `java` workflow runs lint/tests/coverage only
- [ ] Confirm `publish-maven` does not run on PRs or pushes to `main`
- [ ] On next `v*` tag, confirm `publish-maven` runs build then Maven Central deploy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release publishing moves to a dedicated workflow; a misconfigured tag trigger or publish step could still ship artifacts, but behavior is largely unchanged from the removed `release` job.
> 
> **Overview**
> **Splits Java CI from Maven Central releases.** The `java` workflow now only runs on pushes to `main` and pull requests—tag pushes and the in-workflow `release` deploy job are removed so PRs and `main` never trigger publishing.
> 
> **Adds `publish-maven.yml`** for `v*` tags: a `build` job runs lint and `mvn verify`, then a `publish` job (gated with `needs: build`) signs and deploys to Maven Central using the same version-from-tag logic as before. The file sets `permissions: contents: read` and mirrors the separate publish-workflow pattern used for PyPI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2eea7b1d54eb7c17490651b77e4bf74d94613ae. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->